### PR TITLE
Feature 21 - Melody Improvements, New Knobs/Settings, Workflow/Interactivity

### DIFF
--- a/midimasterpiece/pom.xml
+++ b/midimasterpiece/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.vibehistorian.vibecomposer</groupId>
     <artifactId>vibecomposer</artifactId>
     <name>VibeComposer</name>
-    <version>v2.0-beta</version>
+    <version>v2.1-beta</version>
     <packaging>jar</packaging>
 
     <repositories>

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Arrangement.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Arrangement.java
@@ -550,6 +550,35 @@ public class Arrangement {
 		globalVariationMap.put(5, data);
 	}
 
+	private void initGlobalVariationMapFromOldData() {
+		if (getGlobalVariationMap() == null) {
+			initGlobalVariationMap();
+			return;
+		}
+		for (int i = 0; i < 5; i++) {
+			int typesCount = Section.variationDescriptions[i].length - 1;
+			Boolean[] data = new Boolean[typesCount];
+			data[0] = Boolean.TRUE;
+			for (int k = 1; k < typesCount; k++) {
+				data[k] = getBooleanFromOldData1D(globalVariationMap.get(i), k);
+			}
+			globalVariationMap.put(i, data);
+		}
+		Boolean[] data = new Boolean[Section.sectionVariationNames.length + 1];
+		for (int k = 0; k < data.length; k++) {
+			data[k] = getBooleanFromOldData1D(globalVariationMap.get(5), k);
+		}
+		globalVariationMap.put(5, data);
+	}
+
+	private Boolean getBooleanFromOldData1D(Boolean[] oldData, int j) {
+		if (oldData == null || oldData.length <= j) {
+			return Boolean.FALSE;
+		} else {
+			return (Boolean) oldData[j];
+		}
+	}
+
 	public void initGlobalVariationMapIfNull() {
 		if (globalVariationMap.get(0) == null) {
 			initGlobalVariationMap();
@@ -568,6 +597,9 @@ public class Arrangement {
 		initGlobalVariationMapIfNull();
 		if (isOverridden()) {
 			return true;
+		}
+		if (globalVariationMap.get(part).length <= variationOrder + 1) {
+			initGlobalVariationMapFromOldData();
 		}
 		return globalVariationMap.get(part)[variationOrder + 1] == Boolean.TRUE;
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Arrangement.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Arrangement.java
@@ -47,17 +47,18 @@ public class Arrangement {
 			Arrays.asList(new String[] { "INTRO", "CHORUS1", "CHORUS2", "BREAKDOWN", "CHILL",
 					"CHORUS3", "CLIMAX", "CLIMAX", "OUTRO" }));
 	private static final List<String> EDM_ARRANGEMENT = new ArrayList<>(
-			Arrays.asList(new String[] { "INTRO", "BUILDUP", "CHORUS2", "CHORUS3", "VERSE1",
+			Arrays.asList(new String[] { "INTRO", "BUILDUP1", "CHORUS2", "CHORUS3", "VERSE1",
 					"VERSE2", "CHORUS3", "CLIMAX", "OUTRO" }));
 
 	private static final List<String> EDM_ARRANGEMENT2 = new ArrayList<>(
-			Arrays.asList(new String[] { "INTRO", "BUILDUP", "CHORUS2", "CHORUS3", "VERSE1",
-					"BREAKDOWN", "CHILL", "BUILDUP", "CHORUS3", "CLIMAX", "BREAKDOWN", "CHILL",
-					"CLIMAX", "CLIMAX", "HALF_CHORUS", "OUTRO" }));
+			Arrays.asList(new String[] { "INTRO", "BUILDUP1", "CHORUS2", "CHORUS3", "VERSE1",
+					"BREAKDOWN", "CHILL", "BUILDUP1", "BUILDUP2", "CHORUS3", "CLIMAX", "BREAKDOWN",
+					"CHILL", "CLIMAX", "CLIMAX", "HALF_CHORUS", "OUTRO" }));
 
 	private static final List<String> POP_ARRANGEMENT2 = new ArrayList<>(
 			Arrays.asList(new String[] { "HALF_CHORUS", "HALF_CHORUS", "OUTRO", "VERSE2", "CHORUS2",
-					"VERSE2", "CHORUS3", "BREAKDOWN", "BUILDUP", "CHORUS3", "CLIMAX", "OUTRO" }));
+					"VERSE2", "CHORUS3", "BREAKDOWN", "BUILDUP1", "BUILDUP2", "CHORUS3", "CLIMAX",
+					"OUTRO" }));
 
 	static {
 		DEFAULT_ARRANGEMENTS.add(POP_ARRANGEMENT);
@@ -70,14 +71,15 @@ public class Arrangement {
 	static {
 		defaultSections.put("INTRO", new Section("INTRO", 1, 20, 10, 40, 25, 20));
 		defaultSections.put("VERSE1", new Section("VERSE1", 1, 40, 60, 30, 25, 40));
-		defaultSections.put("CHORUS1", new Section("CHORUS1", 1, 50, 90, 50, 35, 50));
-		defaultSections.put("CHORUS2", new Section("CHORUS2", 1, 65, 100, 60, 50, 50));
+		defaultSections.put("VERSE2", new Section("VERSE2", 1, 40, 60, 40, 50, 50));
+		defaultSections.put("CHORUS1", new Section("CHORUS1", 1, 50, 90, 50, 35, 60));
+		defaultSections.put("CHORUS2", new Section("CHORUS2", 1, 65, 100, 60, 50, 70));
 		defaultSections.put("HALF_CHORUS", new Section("HALF_CHORUS", 1, 0, 100, 60, 50, 80));
 		defaultSections.put("BREAKDOWN", new Section("BREAKDOWN", 1, 40, 60, 60, 25, 40));
 		defaultSections.put("CHILL", new Section("CHILL", 1, 10, 30, 70, 70, 10));
-		defaultSections.put("VERSE2", new Section("VERSE2", 1, 40, 60, 40, 50, 50));
 		defaultSections.put("VERSE3", new Section("VERSE3", 1, 50, 80, 40, 70, 60));
-		defaultSections.put("BUILDUP", new Section("BUILDUP", 1, 65, 60, 20, 40, 90));
+		defaultSections.put("BUILDUP1", new Section("BUILDUP1", 1, 40, 40, 10, 20, 70));
+		defaultSections.put("BUILDUP2", new Section("BUILDUP2", 1, 65, 60, 20, 40, 90));
 		defaultSections.put("CHORUS3", new Section("CHORUS3", 1, 80, 100, 80, 80, 85));
 		defaultSections.put("CLIMAX", new Section("CLIMAX", 1, 100, 100, 100, 100, 100));
 		defaultSections.put("OUTRO", new Section("OUTRO", 1, 50, 70, 60, 40, 10));
@@ -100,14 +102,14 @@ public class Arrangement {
 
 	private static final Map<String, String[]> afterinsertsMap = new HashMap<>();
 	static {
-		afterinsertsMap.put("INTRO", new String[] { "VERSE1", "VERSE2", "BUILDUP" });
+		afterinsertsMap.put("INTRO", new String[] { "VERSE1", "VERSE2", "BUILDUP1" });
 
 		afterinsertsMap.put("CHORUS1", new String[] { "VERSE2" });
 		afterinsertsMap.put("CHORUS2", new String[] { "CHORUS3" });
 
 		//afterinsertsMap.put("BREAKDOWN", new String[] { "INTRO" });
 
-		afterinsertsMap.put("CHILL", new String[] { "VERSE2", "BUILDUP" });
+		afterinsertsMap.put("CHILL", new String[] { "VERSE2", "BUILDUP1", "BUILDUP2" });
 	}
 
 	private static final List<String> variableSections = new ArrayList<>(
@@ -206,9 +208,7 @@ public class Arrangement {
 		sections.clear();
 		// type, length, melody%, bass%, chord%, arp%, drum%
 		for (Section s : defaultSections.values()) {
-			if (!s.getType().equals(SectionType.BUILDUP.toString())) {
-				sections.add(s.deepCopy());
-			}
+			sections.add(s.deepCopy());
 		}
 	}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Arrangement.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Arrangement.java
@@ -550,7 +550,7 @@ public class Arrangement {
 		globalVariationMap.put(5, data);
 	}
 
-	private void initGlobalVariationMapFromOldData() {
+	public void initGlobalVariationMapFromOldData() {
 		if (getGlobalVariationMap() == null) {
 			initGlobalVariationMap();
 			return;
@@ -602,5 +602,27 @@ public class Arrangement {
 			initGlobalVariationMapFromOldData();
 		}
 		return globalVariationMap.get(part)[variationOrder + 1] == Boolean.TRUE;
+	}
+
+	public void verifyGlobalVariations() {
+		if (getGlobalVariationMap() == null) {
+			initGlobalVariationMap();
+		}
+		for (int i = 0; i < 6; i++) {
+			if (getGlobalVariationMap().get(i) == null) {
+				initGlobalVariationMap();
+			}
+			if (i < 5) {
+				if (getGlobalVariationMap().get(i).length <= Section.variationDescriptions[i].length
+						- 1) {
+					initGlobalVariationMapFromOldData();
+				}
+			} else {
+				if (getGlobalVariationMap().get(i).length <= Section.sectionVariationNames.length
+						+ 1) {
+					initGlobalVariationMapFromOldData();
+				}
+			}
+		}
 	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Arrangement.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Arrangement.java
@@ -214,7 +214,15 @@ public class Arrangement {
 
 	public TableModel convertToTableModel() {
 
-		TableModel model = new DefaultTableModel(7, getSections().size());
+		TableModel model = new DefaultTableModel(7, getSections().size()) {
+
+			private static final long serialVersionUID = 1471873999987138971L;
+
+			@Override
+			public String getColumnName(int column) {
+				return String.valueOf(column + 1);
+			}
+		};
 		for (int i = 0; i < getSections().size(); i++) {
 			Section s = getSections().get(i);
 			model.setValueAt(s.getType(), 0, i);
@@ -236,6 +244,11 @@ public class Arrangement {
 			@Override
 			public boolean isCellEditable(int row, int col) {
 				return (row == 0);
+			}
+
+			@Override
+			public String getColumnName(int column) {
+				return String.valueOf(column + 1);
 			}
 
 		};

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Chord.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Chord.java
@@ -113,7 +113,7 @@ public class Chord {
 				LG.d("ERROR - Chord pitch: " + pitch);
 			}
 			Note n = new Note(pitch, rhythm, velocity);
-			n.setDuration(getDuration() * MidiGenerator.DEFAULT_DURATION_MULTIPLIER);
+			n.setDuration(getDuration() * MidiGenerator.GLOBAL_DURATION_MULTIPLIER);
 			//n.setOffset(flam * i);
 			noteList.add(n);
 		}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ArpPickerMini.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ArpPickerMini.java
@@ -92,7 +92,7 @@ public class ArpPickerMini extends ScrollComboPanel<ArpPattern> {
 				int max = OMNI.maxOf(originals);
 				int min = OMNI.minOf(originals);
 				pop = new VisualArrayPopup(Math.min(-3, min - 2), Math.max(8, max + 2),
-						valueHolder.getValues());
+						valueHolder.getValues(), true);
 				pop.linkButton(valueHolder);
 				pop.setCloseFunc(e -> {
 					if (!originals.equals(pop.getValues())) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ArpPickerMini.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ArpPickerMini.java
@@ -126,8 +126,8 @@ public class ArpPickerMini extends ScrollComboPanel<ArpPattern> {
 	}
 
 	protected void setRandomCustomValues() {
-		List<Integer> arpPattern = MidiGenerator.makeRandomArpPattern(ap.getHitsPerPattern(),
-				ap.getRepeatableNotes(), new Random());
+		List<Integer> arpPattern = MidiGenerator.makeRandomArpPattern(ap.getHitsPerPattern(), true,
+				new Random());
 		setCustomValues(arpPattern);
 		setVal(ArpPattern.CUSTOM);
 		scb.repaint();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/Chordlet.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/Chordlet.java
@@ -324,7 +324,11 @@ public class Chordlet extends JComponent {
 	}
 
 	public String getChordText() {
-		return firstLetter + sharpString() + spice + (inversion != null ? ("." + inversion) : "");
+		return getSpicedText() + (inversion != null ? ("." + inversion) : "");
+	}
+
+	public String getSpicedText() {
+		return firstLetter + sharpString() + spice;
 	}
 
 	public ChordletPanel getParentPanel() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/Chordlet.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/Chordlet.java
@@ -55,7 +55,7 @@ public class Chordlet extends JComponent {
 	}
 
 	private void setupListeners() {
-		// LMB - first letter/sharp change
+		// RMB - first letter/sharp change
 		SwingUtils.addPopupMenu(this, (evt, e) -> {
 			firstLetter = e.substring(0, 1);
 			sharp = e.length() > 1;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/Chordlet.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/Chordlet.java
@@ -343,4 +343,9 @@ public class Chordlet extends JComponent {
 		dragP = new Point(evt.getPoint());
 	}
 
+	public void updateInversion(int inversion) {
+		this.inversion = inversion;
+		update();
+	}
+
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/CollectionCellRenderer.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/CollectionCellRenderer.java
@@ -111,7 +111,18 @@ public class CollectionCellRenderer extends JComponent implements TableCellRende
 							&& sec.getPartPhraseNotes().get(part).get(partOrder).isCustom();
 					boolean isGlobalCustomMidi = VibeComposerGUI.getInstList(part).get(partOrder)
 							.getCustomMidiToggle();
-					Color subcellColor = OMNI.mixColor(icolor, panelC, isCustomMidi ? 0.66
+					Color instCellColor = OMNI.mixColor(panelC, VibeComposerGUI.instColors[part],
+							part > 0 ? 0.55 : 0.7);
+					if (counter > 0) {
+						Color nextColor = part < 4 ? VibeComposerGUI.instColors[part + 1]
+								: Color.red;
+						double percentageMix = counter / (double) Math.max(counter,
+								VibeComposerGUI.getInstList(part).size());
+
+						instCellColor = OMNI.mixColor(instCellColor, nextColor, percentageMix / 3);
+					}
+
+					Color subcellColor = OMNI.mixColor(instCellColor, panelC, isCustomMidi ? 0.66
 							: (1 - sec.countVariationsForPartAndOrder(part, partOrder)) * 0.66);
 
 					// highlight copier/copiee

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/CollectionCellRenderer.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/CollectionCellRenderer.java
@@ -15,6 +15,7 @@ import javax.swing.table.TableCellRenderer;
 import org.apache.commons.lang3.tuple.Triple;
 import org.vibehistorian.vibecomposer.OMNI;
 import org.vibehistorian.vibecomposer.Section;
+import org.vibehistorian.vibecomposer.SwingUtils;
 import org.vibehistorian.vibecomposer.VibeComposerGUI;
 
 public class CollectionCellRenderer extends JComponent implements TableCellRenderer {
@@ -71,6 +72,7 @@ public class CollectionCellRenderer extends JComponent implements TableCellRende
 			g.setColor(icolor);
 
 			//g.fillRect(0, 0, width, height);
+			String cellDescription = null;
 
 			//g.setColor(OMNI.alphen(Color.black, 127));
 			int widthDivider = Math.max(CollectionCellRenderer.MIN_CELLS + 1, guiPanelsCount + 1);
@@ -135,6 +137,8 @@ public class CollectionCellRenderer extends JComponent implements TableCellRende
 									.equals(Triple.of(part, partOrder, section))) {
 						subcellColor = OMNI.mixColor(subcellColor,
 								VibeComposerGUI.copyDragging ? Color.red : Color.white, 0.3);
+						cellDescription = VibeComposerGUI.getInstList(part).get(partOrder)
+								.getInstrumentBox().getVal();
 					}
 
 					g.setColor(subcellColor);
@@ -213,6 +217,14 @@ public class CollectionCellRenderer extends JComponent implements TableCellRende
 			//LG.d("ListCellRenderer RENDERED");
 			g.setColor(Color.black);
 			g.drawRect(0, 0, width, height);
+
+			g.setColor(new Color(210, 210, 210));
+			if (cellDescription != null
+					&& VibeComposerGUI.arrangementActualTableMousePoint != null) {
+				g.drawString(cellDescription,
+						width / 2 - SwingUtils.getDrawStringWidth(cellDescription) / 2, 10);
+			}
+
 			g.dispose();
 		}
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/FireableComboBox.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/FireableComboBox.java
@@ -1,0 +1,46 @@
+package org.vibehistorian.vibecomposer.Components;
+
+import java.awt.event.ItemEvent;
+import java.util.function.Function;
+
+import javax.swing.JComboBox;
+
+public class FireableComboBox<T> extends JComboBox<T> {
+
+	private static final long serialVersionUID = 3383179107333241378L;
+	ScrollComboPanel<T> parent = null;
+	private Function<Object, String> tooltipFunc = null;
+
+	public FireableComboBox(ScrollComboPanel<T> scrollComboBox) {
+		parent = scrollComboBox;
+	}
+
+	public void _fireItemStateChanged(ItemEvent e) {
+		fireItemStateChanged(e);
+	}
+
+	@Override
+	public void setSelectedIndex(int index) {
+		parent.setVal(getItemAt(index));
+	}
+
+	public Function<Object, String> getTooltipFunc() {
+		return tooltipFunc;
+	}
+
+	public void setTooltipFunc(Function<Object, String> tooltipFunc) {
+		this.tooltipFunc = tooltipFunc;
+	}
+
+	@Override
+	public String getToolTipText() {
+		if (tooltipFunc != null) {
+			tooltipFunc.apply(new Object());
+		}
+		return super.getToolTipText();
+	}
+
+	public String superToolTipText() {
+		return super.getToolTipText();
+	}
+}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/JKnob.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/JKnob.java
@@ -14,6 +14,8 @@ import java.awt.Shape;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
 import java.awt.font.FontRenderContext;
 import java.awt.font.GlyphVector;
 import java.awt.geom.AffineTransform;
@@ -25,6 +27,7 @@ import javax.swing.JComponent;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
+import org.vibehistorian.vibecomposer.MidiUtils;
 import org.vibehistorian.vibecomposer.OMNI;
 import org.vibehistorian.vibecomposer.SwingUtils;
 import org.vibehistorian.vibecomposer.UndoManager;
@@ -154,6 +157,33 @@ public class JKnob extends JComponent
 		setSize(2 * radius, 2 * radius);
 		this.addMouseListener(this);
 		this.addMouseMotionListener(this);
+		addMouseWheelListener(new MouseWheelListener() {
+
+			@Override
+			public void mouseWheelMoved(MouseWheelEvent e) {
+				int val = 0;
+				if (tickSpacing > 0) {
+					int index = tickThresholds.indexOf(curr);
+					if (index < 0) {
+						int closest = MidiUtils.getClosestFromList(tickThresholds, curr);
+						index = tickThresholds.indexOf(closest);
+					}
+					val = tickThresholds.get(
+							OMNI.clamp(index - e.getWheelRotation(), 0, tickThresholds.size() - 1));
+				} else {
+					int scrollAmount = e.isShiftDown() ? 1 : Math.max(1, (max - min) / 20);
+					val = OMNI.clamp(curr - e.getWheelRotation() * scrollAmount, min, max);
+				}
+
+				if (e.isControlDown()) {
+					setValueGlobal(val);
+				} else {
+					setValue(val);
+				}
+
+				repaint();
+			}
+		});
 	}
 
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/JKnob.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/JKnob.java
@@ -351,6 +351,10 @@ public class JKnob extends JComponent
 		if (!valueString.equals(textValue.getText())) {
 			textValue.setText(valueString);
 		}
+
+		if (func != null) {
+			func.accept(new Object());
+		}
 	}
 
 	public void setValue(int val) {
@@ -361,10 +365,6 @@ public class JKnob extends JComponent
 		curr = val;
 
 		setAngle();
-
-		if (func != null) {
-			func.accept(new Object());
-		}
 		repaint();
 	}
 
@@ -782,5 +782,9 @@ public class JKnob extends JComponent
 				e.paintComponent(e.getGraphics());
 			});
 		}
+	}
+
+	public int getValueRaw() {
+		return curr;
 	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
@@ -312,7 +312,7 @@ public class MidiEditArea extends JComponent {
 					int closestNormalized = MidiUtils.getClosestFromList(MidiUtils.MAJ_SCALE,
 							orderVal.y % 12);
 					PhraseNote insertedPn = new PhraseNote(pop.snapToScaleGrid.isSelected()
-							? (12 * (orderVal.y / 12) + closestNormalized)
+							? (MidiUtils.octavePitch(orderVal.y) + closestNormalized)
 							: orderVal.y);
 					insertedPn.setDuration(MidiGenerator.Durations.EIGHTH_NOTE);
 					insertedPn.setRv(0);
@@ -637,7 +637,7 @@ public class MidiEditArea extends JComponent {
 					int pitch = getPitchFromPosition(evt.getPoint().y);
 					if (pop.snapToScaleGrid.isSelected()) {
 						pitch = MidiUtils.getClosestFromList(MidiUtils.MAJ_SCALE, pitch % 12)
-								+ (12 * (pitch / 12));
+								+ MidiUtils.octavePitch(pitch);
 					}
 					boolean playNote = pitch != draggedNote.getPitch();
 					if (draggingAny(DM.MULTIPLE)) {
@@ -646,7 +646,8 @@ public class MidiEditArea extends JComponent {
 							int newPitchAbsolute = selectedNotesCopy.get(i).getPitch()
 									+ pitchChange;
 							int newPitch = MidiUtils.getClosestFromList(MidiUtils.MAJ_SCALE,
-									newPitchAbsolute % 12) + (12 * (newPitchAbsolute / 12));
+									newPitchAbsolute % 12)
+									+ MidiUtils.octavePitch(newPitchAbsolute);
 							selectedNotes.get(i).setPitch(newPitch);
 						}
 					} else {
@@ -694,7 +695,7 @@ public class MidiEditArea extends JComponent {
 				int closestNormalized = MidiUtils.getClosestFromList(MidiUtils.MAJ_SCALE,
 						pitch % 12);
 
-				values.get(pos).setPitch(12 * (pitch / 12) + closestNormalized);
+				values.get(pos).setPitch(MidiUtils.octavePitch(pitch) + closestNormalized);
 			} else {
 				values.get(pos).setPitch(pitch);
 			}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
@@ -940,7 +940,7 @@ public class MidiEditArea extends JComponent {
 					Rectangle rect = getRectFromPoint(mousePoint);
 					g.drawRect(rect.x, rect.y, rect.width, rect.height);
 				}
-				if (highlightedNote != null && highlightedDragLocation != null) {
+				if (dragX != null && highlightedNote != null && highlightedDragLocation != null) {
 					int drawX = bottomLeft.x
 							+ (int) (quarterNoteLength * highlightedNote.getStartTime());
 					int width = (int) (quarterNoteLength * highlightedNote.getDuration());
@@ -949,7 +949,35 @@ public class MidiEditArea extends JComponent {
 					}
 					g.drawLine(drawX, 0, drawX, h);
 				} else {
-					g.drawLine(mousePoint.x, 0, mousePoint.x, h);
+					if (MidiEditPopup.snapToGridChoice) {
+						double time = getTimeFromPosition(mousePoint);
+						time = getClosestToTimeGrid(time);
+						int drawX = bottomLeft.x + (int) (quarterNoteLength * time);
+						g.drawLine(drawX, 0, drawX, h);
+					} else {
+						g.drawLine(mousePoint.x, 0, mousePoint.x, h);
+					}
+
+				}
+			}
+
+			if (pop.displayDrumHelper.isSelected() && pop.getSec() != null
+					&& pop.getSec().getPartPhraseNotes().size() == 5) {
+				g.setColor(OMNI.alphen(nonHighlightedColor, VibeComposerGUI.isDarkMode ? 40 : 80));
+				List<PhraseNotes> noteNotes = pop.getSec().getPartPhraseNotes().get(4);
+				for (int i = 0; i < noteNotes.size(); i++) {
+					noteNotes.get(i).remakeNoteStartTimes();
+					for (int j = 0; j < noteNotes.get(i).size(); j++) {
+						PhraseNote pn = noteNotes.get(i).get(j);
+						int pitch = pn.getPitch();
+						if (pitch < 0) {
+							continue;
+						}
+						int drawX = bottomLeft.x + (int) (quarterNoteLength * pn.getStartTime());
+						int drawY = bottomLeft.y - (int) (rowHeight * (i + 1));
+						int width = (int) (quarterNoteLength * pn.getDuration());
+						g.fillRect(drawX, drawY - 4, width, 8);
+					}
 				}
 			}
 		}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
@@ -201,9 +201,7 @@ public class MidiEditArea extends JComponent {
 
 			@Override
 			public void mouseMoved(MouseEvent e) {
-				if (SwingUtilities.isRightMouseButton(e)) {
-					mousePoint = e.getPoint();
-				}
+				mousePoint = e.getPoint();
 				processHighlight(e.getPoint());
 				processDragEvent(e);
 				setAndRepaint();
@@ -937,9 +935,22 @@ public class MidiEditArea extends JComponent {
 				}
 			}
 
-			if (mousePoint != null && dragX != null) {
-				Rectangle rect = getRectFromPoint(mousePoint);
-				g.drawRect(rect.x, rect.y, rect.width, rect.height);
+			if (mousePoint != null) {
+				if (dragX != null) {
+					Rectangle rect = getRectFromPoint(mousePoint);
+					g.drawRect(rect.x, rect.y, rect.width, rect.height);
+				}
+				if (highlightedNote != null && highlightedDragLocation != null) {
+					int drawX = bottomLeft.x
+							+ (int) (quarterNoteLength * highlightedNote.getStartTime());
+					int width = (int) (quarterNoteLength * highlightedNote.getDuration());
+					if (highlightedDragLocation == 2) {
+						drawX += width;
+					}
+					g.drawLine(drawX, 0, drawX, h);
+				} else {
+					g.drawLine(mousePoint.x, 0, mousePoint.x, h);
+				}
 			}
 		}
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
@@ -179,7 +179,9 @@ public class MidiEditArea extends JComponent {
 				reset();
 				if (SwingUtilities.isLeftMouseButton(evt)
 						&& MidiEditPopup.regenerateInPlaceChoice) {
-					values.setCustom(false);
+					if (pop.applyToMainBtn.isSelected()) {
+						values.setCustom(false);
+					}
 					VibeComposerGUI.vibeComposerGUI.regenerateInPlace();
 				}
 			}
@@ -243,6 +245,8 @@ public class MidiEditArea extends JComponent {
 			if (row >= 0 && row < noteNotes.size()) {
 				pop.part = 4;
 				pop.partOrder = row;
+				pop.applyToMainBtn.setSelectedRaw(
+						VibeComposerGUI.getInstList(4).get(row).getCustomMidiToggle());
 				pop.setup(pop.getSec());
 			}
 
@@ -856,6 +860,7 @@ public class MidiEditArea extends JComponent {
 			// draw actual values
 
 			int ovalWidth = usableHeight / 40;
+			boolean drawDragPosition = draggingAny(DM.NOTE_START, DM.POSITION, DM.DURATION);
 			for (int i = 0; i < numValues; i++) {
 				PhraseNote pn = values.get(i);
 				int pitch = pn.getPitch();
@@ -896,10 +901,9 @@ public class MidiEditArea extends JComponent {
 				}
 
 				g.fillRect(drawX, drawY - 4, width, 8);
-
 				if (highlightedNote != null && pn == highlightedNote
 						&& highlightedDragLocation != null) {
-					boolean drawDragPosition = draggingAny(DM.NOTE_START, DM.POSITION, DM.DURATION);
+
 					switch (highlightedDragLocation) {
 					case 0:
 						g.fillRect(drawX - noteDragMarginX, drawY - 5, noteDragMarginX * 2, 10);
@@ -915,26 +919,21 @@ public class MidiEditArea extends JComponent {
 					}
 
 					g.setColor(OMNI.alphen(VibeComposerGUI.uiColor(), 140));
-
-					switch (highlightedDragLocation) {
-					case 0:
-						if (drawDragPosition) {
+					if (drawDragPosition) {
+						switch (highlightedDragLocation) {
+						case 0:
 							g.drawString(dblDraw3(pn.getStartTime()), drawX - 40, drawY + 15);
-						}
-						break;
-					case 1:
-						if (drawDragPosition) {
+							break;
+						case 1:
 							g.drawString(dblDraw3(pn.getStartTime()), drawX - 20, drawY + 15);
-						}
-						break;
-					case 2:
-						if (drawDragPosition) {
+							break;
+						case 2:
 							g.drawString(dblDraw3(pn.getStartTime() + pn.getDuration()),
 									drawX + width + 20, drawY + 15);
+							break;
 						}
-
-						break;
 					}
+
 				}
 
 				if (draggingAny(DM.VELOCITY_SHAPE)) {
@@ -950,6 +949,7 @@ public class MidiEditArea extends JComponent {
 					Rectangle rect = getRectFromPoint(mousePoint);
 					g.drawRect(rect.x, rect.y, rect.width, rect.height);
 				}
+
 				if (dragX != null && highlightedNote != null && highlightedDragLocation != null) {
 					int drawX = bottomLeft.x
 							+ (int) (quarterNoteLength * highlightedNote.getStartTime());
@@ -959,13 +959,13 @@ public class MidiEditArea extends JComponent {
 					}
 					g.drawLine(drawX, 0, drawX, h);
 				} else {
-					if (MidiEditPopup.snapToGridChoice) {
-						double time = getTimeFromPosition(mousePoint);
-						time = getClosestToTimeGrid(time);
-						int drawX = bottomLeft.x + (int) (quarterNoteLength * time);
-						g.drawLine(drawX, 0, drawX, h);
-					} else {
-						g.drawLine(mousePoint.x, 0, mousePoint.x, h);
+					double time = getTimeFromPosition(mousePoint);
+					time = getClosestToTimeGrid(time);
+					int drawX = bottomLeft.x + (int) (quarterNoteLength * time);
+					g.drawLine(drawX, 0, drawX, h);
+
+					if (!drawDragPosition) {
+						g.drawString(dblDraw3(time), drawX, mousePoint.y);
 					}
 
 				}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
@@ -736,7 +736,8 @@ public class MidiEditArea extends JComponent {
 			// draw line marks
 			for (int i = 0; i < 1 + (max - min); i++) {
 				int drawnInt = min + i + MidiGenerator.DEFAULT_INSTRUMENT_TRANSPOSE[partNum];
-				String drawnValue = "" + (drawnInt) + " | " + MidiUtils.pitchToString(drawnInt);
+				String drawnValue = "" + (drawnInt) + " | "
+						+ MidiUtils.pitchOrDrumToString(drawnInt, pop.part, true);
 				int valueLength = drawnValue.startsWith("-") ? drawnValue.length() + 1
 						: drawnValue.length();
 				int drawValueX = bottomLeft.x / 2 - (numWidth * valueLength) / 2;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
@@ -236,6 +236,16 @@ public class MidiEditArea extends JComponent {
 			playNote(draggedNote);
 
 			dragMode.add(DM.VELOCITY);
+		} else if (pop.displayDrumHelper.isSelected() && pop.getSec() != null
+				&& pop.getSec().getPartPhraseNotes().size() == 5) {
+			int row = getPitchFromPosition(evt.getPoint().y) - min;
+			List<PhraseNotes> noteNotes = pop.getSec().getPartPhraseNotes().get(4);
+			if (row >= 0 && row < noteNotes.size()) {
+				pop.part = 4;
+				pop.partOrder = row;
+				pop.setup(pop.getSec());
+			}
+
 		}
 
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
@@ -243,8 +243,7 @@ public class MidiEditArea extends JComponent {
 			int row = getPitchFromPosition(evt.getPoint().y) - min;
 			List<PhraseNotes> noteNotes = pop.getSec().getPartPhraseNotes().get(4);
 			if (row >= 0 && row < noteNotes.size()) {
-				pop.part = 4;
-				pop.partOrder = row;
+				pop.setupIdentifiers(4, row);
 				pop.applyToMainBtn.setSelectedRaw(
 						VibeComposerGUI.getInstList(4).get(row).getCustomMidiToggle());
 				pop.setup(pop.getSec());

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/RandomIntegerListButton.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/RandomIntegerListButton.java
@@ -27,6 +27,9 @@ public class RandomIntegerListButton extends JButton {
 	Function<? super Object, Map<Integer, Set<Integer>>> highlighterGenerator = null;
 	Consumer<Object> postFunc = null;
 	InstPanel parent = null;
+	public int min = -10;
+	public int max = 10;
+	public boolean editableCount = true;
 
 	public RandomIntegerListButton(String value, InstPanel parent) {
 		this.parent = parent;
@@ -37,7 +40,8 @@ public class RandomIntegerListButton extends JButton {
 				if (SwingUtilities.isLeftMouseButton(e)) {
 					if (isEnabled()) {
 						List<Integer> values = getValues();
-						VisualArrayPopup vap = new VisualArrayPopup(-10, 10, values);
+						VisualArrayPopup vap = new VisualArrayPopup(min, max, values,
+								editableCount);
 						vap.linkButton(RandomIntegerListButton.this);
 					}
 
@@ -63,7 +67,7 @@ public class RandomIntegerListButton extends JButton {
 		setValue(value);
 	}
 
-	protected List<Integer> getValues() {
+	public List<Integer> getValues() {
 		String[] valueSplit = getValue().split(",");
 		List<Integer> values = new ArrayList<>();
 		for (String s : valueSplit) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ScrollComboPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ScrollComboPanel.java
@@ -82,7 +82,9 @@ public class ScrollComboPanel<T> extends TransparentablePanel implements Globall
 					cont.dispatchEvent(SwingUtilities.convertMouseEvent(e.getComponent(), e, cont));
 					return;
 				}
-				prepareInteraction(e.isControlDown());
+				if (!e.isShiftDown()) {
+					prepareInteraction(e.isControlDown());
+				}
 				setSelectedIndex((getSelectedIndex() + e.getWheelRotation() + getItemCount())
 						% getItemCount());
 				ItemEvent evnt = new ItemEvent(scb, ItemEvent.ITEM_STATE_CHANGED, getSelectedItem(),

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ScrollComboPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ScrollComboPanel.java
@@ -1,6 +1,7 @@
 package org.vibehistorian.vibecomposer.Components;
 
 import java.awt.Component;
+import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
@@ -76,8 +77,11 @@ public class ScrollComboPanel<T> extends TransparentablePanel implements Globall
 
 			@Override
 			public void mouseWheelMoved(MouseWheelEvent e) {
-				if (!scrollEnabled || !isEnabled())
+				if (!scrollEnabled || !isEnabled()) {
+					Container cont = ScrollComboPanel.this.getParent();
+					cont.dispatchEvent(SwingUtilities.convertMouseEvent(e.getComponent(), e, cont));
 					return;
+				}
 				prepareInteraction(e.isControlDown());
 				setSelectedIndex((getSelectedIndex() + e.getWheelRotation() + getItemCount())
 						% getItemCount());

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ScrollComboPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ScrollComboPanel.java
@@ -19,7 +19,6 @@ import java.util.stream.IntStream;
 import javax.swing.BoxLayout;
 import javax.swing.ComboBoxEditor;
 import javax.swing.JButton;
-import javax.swing.JComboBox;
 import javax.swing.JLayeredPane;
 import javax.swing.SwingUtilities;
 
@@ -392,24 +391,5 @@ public class ScrollComboPanel<T> extends TransparentablePanel implements Globall
 	@Override
 	public synchronized void addMouseListener(MouseListener l) {
 		scb.addMouseListener(l);
-	}
-}
-
-class FireableComboBox<T> extends JComboBox<T> {
-
-	private static final long serialVersionUID = 3383179107333241378L;
-	ScrollComboPanel<T> parent = null;
-
-	public FireableComboBox(ScrollComboPanel<T> scrollComboBox) {
-		parent = scrollComboBox;
-	}
-
-	public void _fireItemStateChanged(ItemEvent e) {
-		fireItemStateChanged(e);
-	}
-
-	@Override
-	public void setSelectedIndex(int index) {
-		parent.setVal(getItemAt(index));
 	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ScrollComboPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ScrollComboPanel.java
@@ -101,21 +101,15 @@ public class ScrollComboPanel<T> extends TransparentablePanel implements Globall
 							getSelectedItem(), ItemEvent.SELECTED);
 					fireItemStateChanged(evnt);
 				} else if (SwingUtilities.isMiddleMouseButton(evt) && !evt.isAltDown()
-						&& (!evt.isShiftDown() || evt.isControlDown())) {
+						&& !evt.isShiftDown()) {
 					if (evt.isControlDown()) {
-						if (evt.isShiftDown()) {
-							setEnabledGlobal(!isEnabled());
+						if (regenerating) {
+							selectRandomValueGlobal();
 						} else {
 							setEnabled(!isEnabled());
 						}
 					} else {
-						List<Integer> viableIndices = IntStream.iterate(0, e -> e + 1)
-								.limit(getItemCount()).boxed().collect(Collectors.toList());
-						if (viableIndices.size() > 1) {
-							viableIndices.remove(Integer.valueOf(getSelectedIndex()));
-						}
-						setSelectedIndex(
-								viableIndices.get(new Random().nextInt(viableIndices.size())));
+						selectRandomValue();
 					}
 				}
 			}
@@ -137,6 +131,28 @@ public class ScrollComboPanel<T> extends TransparentablePanel implements Globall
 		} else {
 			add(scb);
 		}
+	}
+
+	protected void selectRandomValueGlobal() {
+		InstPanel instParent = SwingUtils.getInstParent(this);
+		if (instParent == null) {
+			selectRandomValue();
+			repaint();
+			return;
+		}
+		instParent.getAllComponentsLike(this, ScrollComboPanel.class).forEach(e -> {
+			e.selectRandomValue();
+			e.repaint();
+		});
+	}
+
+	protected void selectRandomValue() {
+		List<Integer> viableIndices = IntStream.iterate(0, e -> e + 1).limit(getItemCount()).boxed()
+				.collect(Collectors.toList());
+		if (viableIndices.size() > 1) {
+			viableIndices.remove(Integer.valueOf(getSelectedIndex()));
+		}
+		setSelectedIndex(viableIndices.get(new Random().nextInt(viableIndices.size())));
 	}
 
 	public FireableComboBox<T> box() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/SectionInfoCellRenderer.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/SectionInfoCellRenderer.java
@@ -73,7 +73,7 @@ public class SectionInfoCellRenderer extends JComponent implements TableCellRend
 					customChords = "";
 				} else {
 					float newSize = Float.valueOf(fontSize * Math.min(width, 100)
-							/ SwingUtils.getDrawStringWidth(customChords));
+							/ Math.max(60, SwingUtils.getDrawStringWidth(customChords)));
 					g.setFont(font.deriveFont(newSize < fontSizeMin ? fontSizeMin : newSize));
 					g.drawString("[" + customChords + "]", 12, height / 4);
 				}
@@ -82,7 +82,7 @@ public class SectionInfoCellRenderer extends JComponent implements TableCellRend
 					customDurations = "";
 				} else {
 					float newSize = Float.valueOf(fontSize * Math.min(width, 100)
-							/ SwingUtils.getDrawStringWidth(customDurations));
+							/ Math.max(60, SwingUtils.getDrawStringWidth(customDurations)));
 					g.setFont(font.deriveFont(newSize < fontSizeMin ? fontSizeMin : newSize));
 					g.drawString("(" + customDurations + ")", 12, height * 3 / 5);
 				}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/SectionInfoCellRenderer.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/SectionInfoCellRenderer.java
@@ -2,6 +2,7 @@ package org.vibehistorian.vibecomposer.Components;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 
@@ -12,6 +13,7 @@ import javax.swing.table.TableCellRenderer;
 import org.apache.commons.lang3.StringUtils;
 import org.vibehistorian.vibecomposer.MidiGenerator;
 import org.vibehistorian.vibecomposer.Section;
+import org.vibehistorian.vibecomposer.SwingUtils;
 import org.vibehistorian.vibecomposer.VibeComposerGUI;
 
 public class SectionInfoCellRenderer extends JComponent implements TableCellRenderer {
@@ -21,6 +23,10 @@ public class SectionInfoCellRenderer extends JComponent implements TableCellRend
 	private int height = 10;
 	private int width = 10;
 	private int section = 0;
+
+	private static final int fontSize = 8;
+	private static final float fontSizeMin = 7f;
+	private static final Font font = new Font("Tahoma", Font.PLAIN, fontSize);
 
 	public SectionInfoCellRenderer(int w, int h, int col) {
 		height = h;
@@ -48,36 +54,37 @@ public class SectionInfoCellRenderer extends JComponent implements TableCellRend
 				g.setColor(new Color(230, 230, 230));
 				g.drawString("" + sec.getMeasures(), 3, height / 2);
 
-				if (width > 100) {
-					String customDurations = sec.isCustomChordsDurationsEnabled()
-							? sec.getCustomDurations().replaceAll(" ", "")
-							: "";
-					String customChords = ((sec.isCustomChordsDurationsEnabled()
-							|| sec.isDisplayAlternateChords())
-									? sec.getCustomChords().replaceAll(" ", "")
-									: "");
-					String guiUserChords = (VibeComposerGUI.userChordsEnabled.isSelected()
-							? VibeComposerGUI.userChords.getChordListString()
-							: StringUtils.join(MidiGenerator.chordInts, ",")).replaceAll(" ", "");
+				String customDurations = sec.isCustomChordsDurationsEnabled()
+						? sec.getCustomDurations().replaceAll(" ", "")
+						: "";
+				String customChords = ((sec.isCustomChordsDurationsEnabled()
+						|| sec.isDisplayAlternateChords())
+								? sec.getCustomChords().replaceAll(" ", "")
+								: "");
+				String guiUserChords = (VibeComposerGUI.userChordsEnabled.isSelected()
+						? VibeComposerGUI.userChords.getChordListString()
+						: StringUtils.join(MidiGenerator.chordInts, ",")).replaceAll(" ", "");
 
-					String guiUserDurations = (VibeComposerGUI.userChordsEnabled.isSelected()
-							? VibeComposerGUI.userChordsDurations.getText()
-							: "4,4,4,4").replaceAll(" ", "");
+				String guiUserDurations = (VibeComposerGUI.userChordsEnabled.isSelected()
+						? VibeComposerGUI.userChordsDurations.getText()
+						: "4,4,4,4").replaceAll(" ", "");
 
-					if (customChords.trim().isEmpty()
-							|| guiUserChords.equalsIgnoreCase(customChords)) {
-						customChords = "";
-					} else {
-						g.drawString("[" + customChords + "]", 12, height / 4);
-					}
+				if (customChords.trim().isEmpty() || guiUserChords.equalsIgnoreCase(customChords)) {
+					customChords = "";
+				} else {
+					float newSize = Float.valueOf(fontSize * Math.min(width, 100)
+							/ SwingUtils.getDrawStringWidth(customChords));
+					g.setFont(font.deriveFont(newSize < fontSizeMin ? fontSizeMin : newSize));
+					g.drawString("[" + customChords + "]", 12, height / 4);
+				}
 
-					if (customDurations.trim().isEmpty()
-							|| customDurations.equals(guiUserDurations)) {
-						customDurations = "";
-					} else {
-						g.drawString("(" + customDurations + ")", 12, height * 3 / 5);
-						customDurations = "(" + customDurations + ")";
-					}
+				if (customDurations.trim().isEmpty() || customDurations.equals(guiUserDurations)) {
+					customDurations = "";
+				} else {
+					float newSize = Float.valueOf(fontSize * Math.min(width, 100)
+							/ SwingUtils.getDrawStringWidth(customDurations));
+					g.setFont(font.deriveFont(newSize < fontSizeMin ? fontSizeMin : newSize));
+					g.drawString("(" + customDurations + ")", 12, height * 3 / 5);
 				}
 			}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowAreaBig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowAreaBig.java
@@ -235,20 +235,28 @@ public class ShowAreaBig extends JComponent {
 										VibeComposerGUI.currentMidiEditorSectionIndex = phrase.secOrder;
 										return;
 									} else {
-										boolean unsoloAll = false;
-										if (VibeComposerGUI.globalSoloMuter.soloState != State.OFF) {
-											unsoloAll = VibeComposerGUI.isSingleSolo()
-													&& (VibeComposerGUI.getInstList(phrase.part)
-															.get(phrase.partOrder)
-															.getSoloMuter().soloState == State.FULL);
-										}
-										if (!unsoloAll) {
-											VibeComposerGUI.globalSoloMuter.toggleSolo(true);
+										if (evt.isShiftDown()) {
+											// mute, instead of solo
+											VibeComposerGUI.getInstList(phrase.part)
+													.get(phrase.partOrder).getSoloMuter()
+													.toggleMute(true);
+										} else {
+											boolean unsoloAll = false;
+											if (VibeComposerGUI.globalSoloMuter.soloState != State.OFF) {
+												unsoloAll = VibeComposerGUI.isSingleSolo()
+														&& (VibeComposerGUI.getInstList(phrase.part)
+																.get(phrase.partOrder)
+																.getSoloMuter().soloState == State.FULL);
+											}
+											if (!unsoloAll) {
+												VibeComposerGUI.globalSoloMuter.toggleSolo(true);
+											}
+
+											VibeComposerGUI.getInstList(phrase.part)
+													.get(phrase.partOrder).getSoloMuter()
+													.toggleSolo(true);
 										}
 
-										VibeComposerGUI.getInstList(phrase.part)
-												.get(phrase.partOrder).getSoloMuter()
-												.toggleSolo(true);
 										return;
 									}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowAreaBig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowAreaBig.java
@@ -146,6 +146,9 @@ public class ShowAreaBig extends JComponent {
 
 				while (enum1.hasMoreElements()) {
 					PartExt part = (PartExt) enum1.nextElement();
+					if (part.isFillerPart()) {
+						continue;
+					}
 					if (!soloMuterHighlightedTracks.isEmpty()
 							&& !soloMuterHighlightedTracks.contains(part.getTrackNumber())) {
 						continue;
@@ -411,6 +414,9 @@ public class ShowAreaBig extends JComponent {
 		int oldX = 0;
 		while (enum1.hasMoreElements()) {
 			PartExt part = (PartExt) enum1.nextElement();
+			if (part.isFillerPart()) {
+				continue;
+			}
 
 			int noteColorIndex = getIndexForPartName(part.getTitle());
 			//LG.d("Index: " + noteColorIndex);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowAreaBig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowAreaBig.java
@@ -235,9 +235,17 @@ public class ShowAreaBig extends JComponent {
 										VibeComposerGUI.currentMidiEditorSectionIndex = phrase.secOrder;
 										return;
 									} else {
+										boolean unsoloAll = false;
 										if (VibeComposerGUI.globalSoloMuter.soloState != State.OFF) {
+											unsoloAll = VibeComposerGUI.isSingleSolo()
+													&& (VibeComposerGUI.getInstList(phrase.part)
+															.get(phrase.partOrder)
+															.getSoloMuter().soloState == State.FULL);
+										}
+										if (!unsoloAll) {
 											VibeComposerGUI.globalSoloMuter.toggleSolo(true);
 										}
+
 										VibeComposerGUI.getInstList(phrase.part)
 												.get(phrase.partOrder).getSoloMuter()
 												.toggleSolo(true);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowAreaBig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowAreaBig.java
@@ -35,19 +35,25 @@ import java.awt.GradientPaint;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Point;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 
 import javax.swing.JComponent;
+import javax.swing.SwingUtilities;
 
+import org.vibehistorian.vibecomposer.LG;
 import org.vibehistorian.vibecomposer.MidiGenerator;
 import org.vibehistorian.vibecomposer.MidiUtils;
 import org.vibehistorian.vibecomposer.OMNI;
 import org.vibehistorian.vibecomposer.VibeComposerGUI;
 import org.vibehistorian.vibecomposer.Helpers.PartExt;
+import org.vibehistorian.vibecomposer.Helpers.PhraseExt;
 import org.vibehistorian.vibecomposer.Panels.InstPanel;
 import org.vibehistorian.vibecomposer.Panels.SoloMuter.State;
+import org.vibehistorian.vibecomposer.Popups.MidiEditPopup;
 
 import jm.music.data.Note;
 import jm.music.data.Phrase;
@@ -106,133 +112,115 @@ public class ShowAreaBig extends JComponent {
 					+ (float) (1.0 / maxColours * i);
 		}*/
 
-		//		addMouseListener(new MouseAdapter() {
-		//			@Override
-		//			public void mouseReleased(MouseEvent evt) {
-		//				LG.d("Checking note overlap for: " + evt.getPoint());
-		//
-		//				Enumeration<?> enum1 = sp.score.getPartList().elements();
-		//				int prevColorIndex = -1;
-		//				int samePrevColorCounter = 0;
-		//
-		//				Set<Integer> soloMuterHighlightedTracks = new HashSet<>();
-		//				if (ShowPanelBig.soloMuterHighlight != null
-		//						&& ShowPanelBig.soloMuterHighlight.isSelected()) {
-		//					boolean checkMutes = VibeComposerGUI.globalSoloMuter.soloState == State.OFF;
-		//					for (int i = 0; i < 5; i++) {
-		//						for (InstPanel ip : VibeComposerGUI.getInstList(i)) {
-		//							if (checkMutes) {
-		//								if (ip.getSoloMuter().muteState == State.OFF) {
-		//									soloMuterHighlightedTracks.add(ip.getSequenceTrack());
-		//								}
-		//							} else {
-		//								if (ip.getSoloMuter().soloState != State.OFF) {
-		//									soloMuterHighlightedTracks.add(ip.getSequenceTrack());
-		//								}
-		//							}
-		//
-		//						}
-		//					}
-		//				}
-		//
-		//				while (enum1.hasMoreElements()) {
-		//					PartExt part = (PartExt) enum1.nextElement();
-		//
-		//					int noteColorIndex = getIndexForPartName(part.getTitle());
-		//					//LG.d("Index: " + noteColorIndex);
-		//					if (prevColorIndex == noteColorIndex) {
-		//						samePrevColorCounter++;
-		//					} else {
-		//						samePrevColorCounter = 0;
-		//						prevColorIndex = noteColorIndex;
-		//					}
-		//					if (!soloMuterHighlightedTracks.isEmpty()
-		//							&& !soloMuterHighlightedTracks.contains(part.getTrackNumber())) {
-		//						continue;
-		//					}
-		//					Color noteColor = VibeComposerGUI.instColors[noteColorIndex];
-		//					if (samePrevColorCounter > 0) {
-		//						Color nextColor = noteColorIndex < 4
-		//								? VibeComposerGUI.instColors[noteColorIndex + 1]
-		//								: Color.red;
-		//						double percentageMix = samePrevColorCounter
-		//								/ (double) Math.max(samePrevColorCounter,
-		//										VibeComposerGUI.getInstList(noteColorIndex).size());
-		//
-		//						noteColor = OMNI.mixColor(noteColor, nextColor, percentageMix / 1.5);
-		//					}
-		//					Enumeration<?> enum2 = part.getPhraseList().elements();
-		//					int phraseCounter = -1;
-		//					while (enum2.hasMoreElements()) {
-		//						Phrase phrase = (Phrase) enum2.nextElement();
-		//						phraseCounter++;
-		//						if (phrase.getHighestPitch() < 0) {
-		//							continue;
-		//						}
-		//
-		//						Enumeration<?> enum3 = phrase.getNoteList().elements();
-		//						double oldXBeat = phrase.getStartTime();
-		//						oldXMouse = (int) (Math.round(oldXBeat * beatWidth));
-		//
-		//						while (enum3.hasMoreElements()) {
-		//							Note aNote = (Note) enum3.nextElement();
-		//							int currNote = -1;
-		//							if (aNote.getPitchType() == Note.MIDI_PITCH)
-		//								currNote = aNote.getPitch();
-		//							else
-		//								currNote = Note.freqToMidiPitch(aNote.getFrequency());
-		//
-		//							if (currNote < 0) {
-		//								//LG.d("(NOT) PRINTING EMPTY NOTE!");
-		//								oldXBeat += aNote.getRhythmValue();
-		//								oldXMouse = (int) (Math.round(oldXBeat * beatWidth));
-		//								continue;
-		//							}
-		//							//LG.d("Note: " + currNote);
-		//							if ((currNote <= 127) && (currNote >= 0)) {
-		//								int y = getNotePosY(currNote);
-		//
-		//								double durationTrimmer = ShowPanelBig.trimNoteLengthBox
-		//										.getSelectedIndex() > 0
-		//												? noteTrimValues[ShowPanelBig.trimNoteLengthBox
-		//														.getSelectedIndex() - 1]
-		//												: 1000;
-		//
-		//
-		//								int x = (int) (Math
-		//										.round(Math.min(durationTrimmer, aNote.getDuration())
-		//												* beatWidth));
-		//
-		//								if (x < 1)
-		//									x = 1;
-		//
-		//								int noteOffsetXOffset = (int) (aNote.getOffset() * beatWidth);
-		//								int actualStartingX = oldXMouse + noteOffsetXOffset;
-		//
-		//								int actualHeight = (noteHeight > 7 ? noteHeight * 7 / 10
-		//										: noteHeight) - thinNote;
-		//
-		//								boolean pointInRect = OMNI.pointInRect(evt.getPoint(),
-		//										actualStartingX, y - actualHeight, x, actualHeight * 2);
-		//								if (pointInRect) {
-		//									LG.i("Opening popup for section#: " + phraseCounter);
-		//									VibeComposerGUI.currentMidiEditorPopup = new MidiEditPopup(
-		//											VibeComposerGUI.actualArrangement.getSections()
-		//													.get(phraseCounter),
-		//											noteColorIndex, samePrevColorCounter);
-		//									VibeComposerGUI.currentMidiEditorPopup
-		//											.setSec(VibeComposerGUI.actualArrangement.getSections()
-		//													.get(phraseCounter));
-		//									VibeComposerGUI.currentMidiEditorSectionIndex = phraseCounter;
-		//								}
-		//							}
-		//							oldXBeat += aNote.getRhythmValue();
-		//							oldXMouse = (int) (Math.round(oldXBeat * beatWidth));
-		//						}
-		//					}
-		//				}
-		//			}
-		//		});
+		addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseReleased(MouseEvent evt) {
+				if (!SwingUtilities.isLeftMouseButton(evt)) {
+					return;
+				}
+				LG.d("Checking note overlap for: " + evt.getPoint());
+
+				Enumeration<?> enum1 = sp.score.getPartList().elements();
+				double beatWidth = sp.beatWidth;
+				Set<Integer> soloMuterHighlightedTracks = new HashSet<>();
+				if (ShowPanelBig.soloMuterHighlight != null
+						&& ShowPanelBig.soloMuterHighlight.isSelected()) {
+					boolean checkMutes = VibeComposerGUI.globalSoloMuter.soloState == State.OFF;
+					for (int i = 0; i < 5; i++) {
+						for (InstPanel ip : VibeComposerGUI.getInstList(i)) {
+							if (checkMutes) {
+								if (ip.getSoloMuter().muteState == State.OFF) {
+									soloMuterHighlightedTracks.add(ip.getSequenceTrack());
+								}
+							} else {
+								if (ip.getSoloMuter().soloState != State.OFF) {
+									soloMuterHighlightedTracks.add(ip.getSequenceTrack());
+								}
+							}
+
+						}
+					}
+				}
+
+				while (enum1.hasMoreElements()) {
+					PartExt part = (PartExt) enum1.nextElement();
+					if (!soloMuterHighlightedTracks.isEmpty()
+							&& !soloMuterHighlightedTracks.contains(part.getTrackNumber())) {
+						continue;
+					}
+
+					Enumeration<?> enum2 = part.getPhraseList().elements();
+					while (enum2.hasMoreElements()) {
+						PhraseExt phrase = (PhraseExt) enum2.nextElement();
+						double oldXBeat = phrase.getStartTime();
+
+						if (phrase.getHighestPitch() < 0) {
+							continue;
+						}
+
+						Enumeration<?> enum3 = phrase.getNoteList().elements();
+						oldXMouse = (int) (Math.round(oldXBeat * beatWidth));
+
+						while (enum3.hasMoreElements()) {
+							Note aNote = (Note) enum3.nextElement();
+							int currNote = -1;
+							if (aNote.getPitchType() == Note.MIDI_PITCH)
+								currNote = aNote.getPitch();
+							else
+								currNote = Note.freqToMidiPitch(aNote.getFrequency());
+
+							if (currNote < 0) {
+								//LG.d("(NOT) PRINTING EMPTY NOTE!");
+								oldXBeat += aNote.getRhythmValue();
+								oldXMouse = (int) (Math.round(oldXBeat * beatWidth));
+								continue;
+							}
+							//LG.d("Note: " + currNote);
+							if ((currNote <= 127) && (currNote >= 0)) {
+								int y = getNotePosY(currNote);
+
+								double durationTrimmer = ShowPanelBig.trimNoteLengthBox
+										.getSelectedIndex() > 0
+												? noteTrimValues[ShowPanelBig.trimNoteLengthBox
+														.getSelectedIndex() - 1]
+												: 1000;
+
+
+								int x = (int) (Math
+										.round(Math.min(durationTrimmer, aNote.getDuration())
+												* beatWidth));
+
+								if (x < 1)
+									x = 1;
+
+								int noteOffsetXOffset = (int) (aNote.getOffset() * beatWidth);
+								int actualStartingX = oldXMouse + noteOffsetXOffset;
+
+								int actualHeight = (noteHeight > 7 ? noteHeight * 7 / 10
+										: noteHeight) - thinNote;
+
+								boolean pointInRect = OMNI.pointInRect(evt.getPoint(),
+										actualStartingX, y - actualHeight, x, actualHeight * 2);
+								if (pointInRect) {
+									LG.i("Opening popup for section#: " + phrase.secOrder);
+									VibeComposerGUI.currentMidiEditorPopup = new MidiEditPopup(
+											VibeComposerGUI.actualArrangement.getSections()
+													.get(phrase.secOrder),
+											phrase.part, phrase.partOrder);
+									VibeComposerGUI.currentMidiEditorPopup
+											.setSec(VibeComposerGUI.actualArrangement.getSections()
+													.get(phrase.secOrder));
+									VibeComposerGUI.currentMidiEditorSectionIndex = phrase.secOrder;
+									return;
+								}
+							}
+							oldXBeat += aNote.getRhythmValue();
+							oldXMouse = (int) (Math.round(oldXBeat * beatWidth));
+						}
+					}
+				}
+			}
+		});
 	}
 
 	private void reInit() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowAreaBig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowAreaBig.java
@@ -526,7 +526,8 @@ public class ShowAreaBig extends JComponent {
 								noteDescription = VibeComposerGUI.instNames[phrase.part] + "#"
 										+ VibeComposerGUI.getInstList(phrase.part)
 												.get(phrase.partOrder).getPanelOrder()
-										+ "|" + MidiUtils.getNoteForPitch(currNote);
+										+ "|" + MidiUtils.pitchOrDrumToString(currNote, phrase.part,
+												false);
 								mouseProcessed = true;
 								mouseHighlightedNote = true;
 							}
@@ -596,7 +597,7 @@ public class ShowAreaBig extends JComponent {
 			for (int i = 15; i < 105; i++) {
 				if (MidiUtils.MAJ_SCALE.contains(i % 12)) {
 					int y = getNotePosY(i) + (int) (usedFontHeight / 4) + 2;
-					String noteString = MidiUtils.getNoteForPitch(i);
+					String noteString = MidiUtils.pitchToString(i);
 					g.drawString(noteString, viewPoint.x, y);
 				}
 			}
@@ -604,7 +605,7 @@ public class ShowAreaBig extends JComponent {
 
 		if (mouseProcessed && noteDescription != null) {
 			g.setColor(new Color(210, 210, 210));
-			g.drawString(noteDescription, mousePoint.x, mousePoint.y);
+			g.drawString(noteDescription, mousePoint.x + 10, mousePoint.y - 10);
 		}
 
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowAreaBig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowAreaBig.java
@@ -115,9 +115,11 @@ public class ShowAreaBig extends JComponent {
 		addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseReleased(MouseEvent evt) {
-				if (!SwingUtilities.isLeftMouseButton(evt)) {
+				if (!SwingUtilities.isLeftMouseButton(evt)
+						&& !SwingUtilities.isMiddleMouseButton(evt)) {
 					return;
 				}
+				boolean popupOpen = SwingUtilities.isLeftMouseButton(evt);
 				LG.d("Checking note overlap for: " + evt.getPoint());
 
 				Enumeration<?> enum1 = sp.score.getPartList().elements();
@@ -202,16 +204,27 @@ public class ShowAreaBig extends JComponent {
 								boolean pointInRect = OMNI.pointInRect(evt.getPoint(),
 										actualStartingX, y - actualHeight, x, actualHeight * 2);
 								if (pointInRect) {
-									LG.i("Opening popup for section#: " + phrase.secOrder);
-									VibeComposerGUI.currentMidiEditorPopup = new MidiEditPopup(
-											VibeComposerGUI.actualArrangement.getSections()
-													.get(phrase.secOrder),
-											phrase.part, phrase.partOrder);
-									VibeComposerGUI.currentMidiEditorPopup
-											.setSec(VibeComposerGUI.actualArrangement.getSections()
-													.get(phrase.secOrder));
-									VibeComposerGUI.currentMidiEditorSectionIndex = phrase.secOrder;
-									return;
+									if (popupOpen) {
+										LG.i("Opening popup for section#: " + phrase.secOrder);
+										VibeComposerGUI.currentMidiEditorPopup = new MidiEditPopup(
+												VibeComposerGUI.actualArrangement.getSections()
+														.get(phrase.secOrder),
+												phrase.part, phrase.partOrder);
+										VibeComposerGUI.currentMidiEditorPopup
+												.setSec(VibeComposerGUI.actualArrangement
+														.getSections().get(phrase.secOrder));
+										VibeComposerGUI.currentMidiEditorSectionIndex = phrase.secOrder;
+										return;
+									} else {
+										if (VibeComposerGUI.globalSoloMuter.soloState != State.OFF) {
+											VibeComposerGUI.globalSoloMuter.toggleSolo(true);
+										}
+										VibeComposerGUI.getInstList(phrase.part)
+												.get(phrase.partOrder).getSoloMuter()
+												.toggleSolo(true);
+										return;
+									}
+
 								}
 							}
 							oldXBeat += aNote.getRhythmValue();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowPanelBig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowPanelBig.java
@@ -72,8 +72,8 @@ public class ShowPanelBig extends JPanel {
 	protected double beatWidth; //10.0;
 	public static final int beatWidthBaseDefault = 1500;
 	public static int beatWidthBase = 1550;
-	public static final List<Integer> beatWidthBases = Arrays
-			.asList(new Integer[] { 1550, 1800, 2200, 2700, 3300, 4000, 4800, 5700, 6800 });
+	public static final List<Integer> beatWidthBases = Arrays.asList(new Integer[] { 1550, 1800,
+			2200, 2700, 3300, 4000, 4800, 5700, 6800, 8200, 10000, 12500 });
 	public static int beatWidthBaseIndex = 0;
 	public static int panelMaxHeight = VibeComposerGUI.scrollPaneDimension.height;
 	private ShowAreaBig sa;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowPanelBig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowPanelBig.java
@@ -143,7 +143,7 @@ public class ShowPanelBig extends JPanel {
 		scorePartPanel.add(scoreBox);
 		scorePartPanel.add(new JLabel("Included Parts"));
 		for (int i = 0; i < 5; i++) {
-			partsShown[i] = new CheckButton(VibeComposerGUI.instNames[i], i < 4,
+			partsShown[i] = new CheckButton(VibeComposerGUI.instNames[i], true,
 					OMNI.alphen(VibeComposerGUI.instColors[i], 75));
 			partsShown[i].setRunnable(() -> setScore());
 			int fI = i;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowPanelBig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowPanelBig.java
@@ -151,8 +151,15 @@ public class ShowPanelBig extends JPanel {
 				@Override
 				public void mousePressed(MouseEvent evt) {
 					if (SwingUtilities.isMiddleMouseButton(evt)) {
+						boolean enableAll = true;
 						for (int j = 0; j < 5; j++) {
-							partsShown[j].setSelectedRaw(j == fI);
+							if (j != fI && partsShown[j].isSelected()) {
+								enableAll = false;
+							}
+						}
+
+						for (int j = 0; j < 5; j++) {
+							partsShown[j].setSelectedRaw(j == fI || enableAll);
 						}
 						setScore();
 					}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/VeloRect.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/VeloRect.java
@@ -10,6 +10,8 @@ import java.awt.Point;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionListener;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
 
 import javax.swing.JComponent;
 import javax.swing.SwingUtilities;
@@ -41,10 +43,10 @@ public class VeloRect extends JComponent {
 	private VisualPatternPanel visualParent = null;
 	private int visualParentOrderIndex = -1;
 
-	public VeloRect(int min, int max, int currentVal) {
+	public VeloRect(int minimum, int maximum, int currentVal) {
 		super();
-		this.min = min;
-		this.max = max;
+		this.min = minimum;
+		this.max = maximum;
 		this.val = currentVal;
 		this.defaultVal = currentVal;
 		addMouseListener(new MouseAdapter() {
@@ -87,6 +89,16 @@ public class VeloRect extends JComponent {
 				}
 			}
 
+		});
+
+		addMouseWheelListener(new MouseWheelListener() {
+
+			@Override
+			public void mouseWheelMoved(MouseWheelEvent e) {
+				int scrollAmount = Math.max(1, (max - min) / 20);
+				setValue(OMNI.clamp(val - e.getWheelRotation() * scrollAmount, min, max));
+				repaint();
+			}
 		});
 		setOpaque(true);
 		updateSizes(defaultSize);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Enums/StrumType.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Enums/StrumType.java
@@ -125,8 +125,8 @@ public enum StrumType {
 class Strums {
 
 	public static final List<Integer> STRUM_ARP = Arrays
-			.asList(new Integer[] { 250, 333, 500, 666, 1000, 1500, 2000 });
+			.asList(new Integer[] { 250, 333, 375, 500, 666, 1000, 1500, 2000 });
 	public static final List<Integer> STRUM_MED = Arrays
-			.asList(new Integer[] { 62, 125, 250, 333 });
+			.asList(new Integer[] { 62, 125, 250, 333, 375 });
 	public static final List<Integer> STRUM_HUMAN = Arrays.asList(new Integer[] { 31, 62, 125 });
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
@@ -97,6 +97,7 @@ public class GUIConfig {
 	private boolean melodyPatternFlip = false;
 	private int melodyBlockTargetMode = 2;
 	private int melodyPatternEffect = 2;
+	private int melodyRhythmAccents = 0;
 
 	// chord gen
 	private int chordSlashChance = 0;
@@ -811,6 +812,14 @@ public class GUIConfig {
 
 	public void setTransposedNotesForceScale(boolean transposedNotesForceScale) {
 		this.transposedNotesForceScale = transposedNotesForceScale;
+	}
+
+	public int getMelodyRhythmAccents() {
+		return melodyRhythmAccents;
+	}
+
+	public void setMelodyRhythmAccents(int melodyRhythmAccents) {
+		this.melodyRhythmAccents = melodyRhythmAccents;
 	}
 
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
@@ -98,6 +98,8 @@ public class GUIConfig {
 	private int melodyBlockTargetMode = 2;
 	private int melodyPatternEffect = 2;
 	private int melodyRhythmAccents = 0;
+	private int melodyRhythmAccentsMode = 0;
+	private boolean melodyRhythmAccentsPocket = false;
 
 	// chord gen
 	private int chordSlashChance = 0;
@@ -820,6 +822,22 @@ public class GUIConfig {
 
 	public void setMelodyRhythmAccents(int melodyRhythmAccents) {
 		this.melodyRhythmAccents = melodyRhythmAccents;
+	}
+
+	public int getMelodyRhythmAccentsMode() {
+		return melodyRhythmAccentsMode;
+	}
+
+	public void setMelodyRhythmAccentsMode(int melodyRhythmAccentsMode) {
+		this.melodyRhythmAccentsMode = melodyRhythmAccentsMode;
+	}
+
+	public boolean isMelodyRhythmAccentsPocket() {
+		return melodyRhythmAccentsPocket;
+	}
+
+	public void setMelodyRhythmAccentsPocket(boolean melodyRhythmAccentsPocket) {
+		this.melodyRhythmAccentsPocket = melodyRhythmAccentsPocket;
 	}
 
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
@@ -674,6 +674,22 @@ public class GUIConfig {
 		this.melodyNotes = melodyNotes;
 	}
 
+	public boolean isPartEnabled(int partNum) {
+		switch (partNum) {
+		case 0:
+			return melodyEnable;
+		case 1:
+			return bassEnable;
+		case 2:
+			return chordsEnable;
+		case 3:
+			return arpsEnable;
+		case 4:
+			return drumsEnable;
+		}
+		throw new IllegalArgumentException("Invalid partNum");
+	}
+
 	public boolean isMelodyEnable() {
 		return melodyEnable;
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
@@ -92,6 +92,8 @@ public class GUIConfig {
 	private boolean melodyArpySurprises = false;
 	private boolean melodySingleNoteExceptions = false;
 	private boolean melodyFillPausesPerChord = false;
+	private boolean melodyLegacyMode = false;
+
 	private boolean melodyAvoidChordJumps = false;
 	private boolean melodyUseDirectionsFromProgression = true;
 	private boolean melodyPatternFlip = false;
@@ -838,6 +840,14 @@ public class GUIConfig {
 
 	public void setMelodyRhythmAccentsPocket(boolean melodyRhythmAccentsPocket) {
 		this.melodyRhythmAccentsPocket = melodyRhythmAccentsPocket;
+	}
+
+	public boolean isMelodyLegacyMode() {
+		return melodyLegacyMode;
+	}
+
+	public void setMelodyLegacyMode(boolean melodyLegacyMode) {
+		this.melodyLegacyMode = melodyLegacyMode;
 	}
 
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
@@ -119,7 +119,6 @@ public class GUIConfig {
 
 	// arp gen
 	private boolean useOctaveAdjustments = false;
-	private int maxArpSwing = 50;
 
 	// drum gen
 	private boolean drumCustomMapping = true;
@@ -433,14 +432,6 @@ public class GUIConfig {
 
 	public void setUseOctaveAdjustments(boolean useOctaveAdjustments) {
 		this.useOctaveAdjustments = useOctaveAdjustments;
-	}
-
-	public int getMaxArpSwing() {
-		return maxArpSwing;
-	}
-
-	public void setMaxArpSwing(int maxArpSwing) {
-		this.maxArpSwing = maxArpSwing;
 	}
 
 	public int getMaxMelodySwing() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Helpers/PartExt.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Helpers/PartExt.java
@@ -10,6 +10,7 @@ public class PartExt extends Part {
 	private static final long serialVersionUID = 4441440891894095L;
 
 	private int trackNumber = -1;
+	private boolean fillerPart = false;
 
 	public PartExt(String string, int i, int j) {
 		super(string, i, j);
@@ -37,6 +38,21 @@ public class PartExt extends Part {
 		i.setTimeIndex(this.getTimeIndex());
 		i.setMyScore(this.getMyScore());
 		i.setTrackNumber(this.getTrackNumber());
+		i.setFillerPart(this.isFillerPart());
 		return i;
+	}
+
+	public boolean isFillerPart() {
+		return fillerPart;
+	}
+
+	public void setFillerPart(boolean fillerPart) {
+		this.fillerPart = fillerPart;
+	}
+
+	public static PartExt makeFillerPart() {
+		PartExt pe = new PartExt("Filler", 0, 1);
+		pe.setFillerPart(true);
+		return pe;
 	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Helpers/PartExt.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Helpers/PartExt.java
@@ -30,8 +30,8 @@ public class PartExt extends Part {
 		i = new PartExt(this.getTitle() + " copy", this.getInstrument(), this.getChannel());
 		Enumeration enum1 = this.getPhraseList().elements();
 		while (enum1.hasMoreElements()) {
-			Phrase oldPhrase = (Phrase) enum1.nextElement();
-			i.addPhrase((Phrase) oldPhrase.copy());
+			PhraseExt oldPhrase = (PhraseExt) enum1.nextElement();
+			i.addPhrase((PhraseExt) oldPhrase.copy());
 		}
 
 		i.setTempo(this.getTempo());

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Helpers/PhraseExt.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Helpers/PhraseExt.java
@@ -23,6 +23,13 @@ public class PhraseExt extends Phrase {
 		this.secOrder = secOrder;
 	}
 
+	public PhraseExt(PhraseExt firstPhrase, double startTime) {
+		part = firstPhrase.part;
+		partOrder = firstPhrase.partOrder;
+		secOrder = firstPhrase.secOrder;
+		setStartTime(startTime);
+	}
+
 	@Override
 	public Phrase copy() {
 		Phrase phr = new PhraseExt(part, partOrder, secOrder);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Helpers/PhraseExt.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Helpers/PhraseExt.java
@@ -1,0 +1,50 @@
+package org.vibehistorian.vibecomposer.Helpers;
+
+
+import java.util.Enumeration;
+
+import jm.music.data.Note;
+import jm.music.data.Phrase;
+
+public class PhraseExt extends Phrase {
+
+	private static final long serialVersionUID = -3149703478694332198L;
+	public int part = 0;
+	public int partOrder = 0;
+	public int secOrder = 0;
+
+	public PhraseExt() {
+		super();
+	}
+
+	public PhraseExt(int partNum, int absoluteOrder, int secOrder) {
+		part = partNum;
+		partOrder = absoluteOrder;
+		this.secOrder = secOrder;
+	}
+
+	@Override
+	public Phrase copy() {
+		Phrase phr = new PhraseExt(part, partOrder, secOrder);
+		copyAttribs(phr);
+		Enumeration enum1 = this.getNoteList().elements();
+		while (enum1.hasMoreElements()) {
+			phr.addNote(((Note) enum1.nextElement()).copy());
+		}
+		return phr;
+	}
+
+	private void copyAttribs(Phrase phr) {
+		// NB: start time now covered by position
+		phr.setStartTime(getStartTime());
+		phr.setTitle(getTitle() + " copy");
+		phr.setInstrument(getInstrument());
+		phr.setAppend(getAppend());
+		phr.setPan(getPan());
+		phr.setLinkedPhrase(getLinkedPhrase());
+		phr.setMyPart(getMyPart());
+		phr.setTempo(getTempo());
+		phr.setNumerator(getNumerator());
+		phr.setDenominator(getDenominator());
+	}
+}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Helpers/PhraseNotes.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Helpers/PhraseNotes.java
@@ -41,7 +41,7 @@ public class PhraseNotes extends ArrayList<PhraseNote> implements Cloneable {
 	}
 
 	public Phrase makePhrase() {
-		Phrase phr = new Phrase();
+		Phrase phr = new PhraseExt();
 		makeNotes().forEach(e -> phr.addNote(e));
 		return phr;
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/InstComboBox.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/InstComboBox.java
@@ -18,20 +18,6 @@ public class InstComboBox extends ScrollComboBox<String> {
 		return instPool;
 	}
 
-	@Override
-	public String getToolTipText() {
-		if (super.getToolTipText() == null) {
-			return null;
-		}
-		if (instPool == InstUtils.POOL.DRUM) {
-			int pitch = MidiGenerator.mapDrumPitchByCustomMapping(getInstrument(), false);
-			putClientProperty(TOOL_TIP_TEXT_KEY,
-					(pitch + " / " + MidiUtils.getNoteForPitch(pitch)));
-		}
-
-		return super.getToolTipText();
-	}
-
 	public void setInstPool(InstUtils.POOL instPool) {
 		this.instPool = instPool;
 	}
@@ -45,6 +31,18 @@ public class InstComboBox extends ScrollComboBox<String> {
 				this.addItem(c);
 			}
 		}
+		box().setTooltipFunc(e -> {
+			if (box().superToolTipText() == null) {
+				return null;
+			}
+			if (instPool == InstUtils.POOL.DRUM) {
+				int pitch = MidiGenerator.mapDrumPitchByCustomMapping(getInstrument(), false);
+				box().putClientProperty(TOOL_TIP_TEXT_KEY,
+						(pitch + " / " + MidiUtils.pitchToString(pitch)));
+			}
+
+			return box().superToolTipText();
+		});
 	}
 
 	public void changeInstPoolMapping(String[] pool) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/InstComboBox.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/InstComboBox.java
@@ -57,6 +57,9 @@ public class InstComboBox extends ScrollComboBox<String> {
 	}
 
 	public InstUtils.POOL setInstrument(int instrument) {
+		if (!isEnabled()) {
+			return instPool;
+		}
 		if (!instSet(instrument)) {
 			initInstPool(InstUtils.POOL.ALL);
 			LG.d("Switching to POOL.ALL!");

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/InstComboBox.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/InstComboBox.java
@@ -64,8 +64,8 @@ public class InstComboBox extends ScrollComboBox<String> {
 			initInstPool(InstUtils.POOL.ALL);
 			LG.d("Switching to POOL.ALL!");
 			if (!instSet(instrument)) {
-				throw new IllegalArgumentException(
-						"Instrument not found in POOL.ALL: " + instrument);
+				LG.e("Instrument not found in POOL.ALL: " + instrument);
+				setInstrument(getRandomInstrument());
 			}
 		}
 		return instPool;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/JMusicUtilsCustom.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/JMusicUtilsCustom.java
@@ -45,7 +45,7 @@ public class JMusicUtilsCustom implements JMC {
 			return;
 		// the new phrase has the start time of the earliest one
 		PhraseExt firstPhrase = (PhraseExt) phr[0];
-		Phrase nphr = new Phrase(firstPhrase.getStartTime());
+		Phrase nphr = new PhraseExt(firstPhrase, firstPhrase.getStartTime());
 
 		Note n;
 		boolean finished = false;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/JMusicUtilsCustom.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/JMusicUtilsCustom.java
@@ -15,6 +15,7 @@ import java.util.Vector;
 import org.apache.commons.lang3.tuple.Pair;
 import org.vibehistorian.vibecomposer.MidiGenerator.Durations;
 import org.vibehistorian.vibecomposer.Helpers.PartExt;
+import org.vibehistorian.vibecomposer.Helpers.PhraseExt;
 
 import jm.JMC;
 import jm.midi.SMF;
@@ -43,7 +44,8 @@ public class JMusicUtilsCustom implements JMC {
 		if (phr.length < 2)
 			return;
 		// the new phrase has the start time of the earliest one
-		Phrase nphr = new Phrase(phr[0].getStartTime());
+		PhraseExt firstPhrase = (PhraseExt) phr[0];
+		Phrase nphr = new Phrase(firstPhrase.getStartTime());
 
 		Note n;
 		boolean finished = false;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/JMusicUtilsCustom.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/JMusicUtilsCustom.java
@@ -135,6 +135,9 @@ public class JMusicUtilsCustom implements JMC {
 		Enumeration<?> enum1 = score.getPartList().elements();
 		while (enum1.hasMoreElements()) {
 			PartExt part = (PartExt) enum1.nextElement();
+			if (part.isFillerPart()) {
+				continue;
+			}
 			scrCopy.addPart(part.copy());
 		}
 
@@ -236,7 +239,7 @@ public class JMusicUtilsCustom implements JMC {
 		Enumeration aEnum = score.getPartList().elements();
 		while (aEnum.hasMoreElements()) {
 			Track smfTrack = new Track();
-			Part inst = (Part) aEnum.nextElement();
+			PartExt inst = (PartExt) aEnum.nextElement();
 			System.out.print("    Part " + partCount + " '" + inst.getTitle()
 					+ "' to SMF Track on Ch. " + inst.getChannel() + ": ");
 			partCount++;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/JMusicUtilsCustom.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/JMusicUtilsCustom.java
@@ -37,6 +37,7 @@ import jm.music.tools.Mod;
 public class JMusicUtilsCustom implements JMC {
 
 	private static double tickRemainder = 0.0;
+	private static final short DEFAULT_PPQN = 960;
 
 	public static void consolidate(Part p) {
 
@@ -199,7 +200,7 @@ public class JMusicUtilsCustom implements JMC {
 
 	public static void midi(Score scr, String fileName) {
 		//Score s = adjustTempo(scr);
-		SMF smf = new SMF();
+		SMF smf = new SMF((short) 1, DEFAULT_PPQN);
 		try {
 			double time1 = System.currentTimeMillis();
 			LG.d("----------------------------- Writing MIDI File ------------------------------");
@@ -447,9 +448,9 @@ public class JMusicUtilsCustom implements JMC {
 	 * This method wriiten by Bob Lee.
 	 */
 	private static double tickRounder(double timeValue) {
-		final double tick = 1. / 480.;
-		final double halfTick = 1. / 960.;
-		int ticks = (int) (timeValue * 480.);
+		final double tick = 1. / (double) DEFAULT_PPQN;
+		final double halfTick = 1. / (DEFAULT_PPQN * 2.);
+		int ticks = (int) (timeValue * (double) DEFAULT_PPQN);
 		double rounded = ((double) ticks) * tick;
 		tickRemainder += timeValue - rounded;
 		if (tickRemainder > halfTick) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/LG.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/LG.java
@@ -22,6 +22,22 @@ public class LG {
 		LOGGER.warn(msg);
 	}
 
+	public static void d(String msg, Throwable t) {
+		LOGGER.debug(msg, t);
+	}
+
+	public static void i(String msg, Throwable t) {
+		LOGGER.info(msg, t);
+	}
+
+	public static void e(String msg, Throwable t) {
+		LOGGER.error(msg, t);
+	}
+
+	public static void w(String msg, Throwable t) {
+		LOGGER.warn(msg, t);
+	}
+
 	public static void d(Object msg) {
 		LOGGER.debug(msg == null ? null : msg.toString());
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
@@ -525,7 +525,7 @@ public class MelodyUtils {
 		sorted.addAll(others);
 		sorted.addAll(main16th);
 		sorted.addAll(main8th);
-		LG.i("Others: " + others.size() + ", 16th: " + main16th.size() + ", 8th: "
+		LG.n("Others: " + others.size() + ", 16th: " + main16th.size() + ", 8th: "
 				+ main8th.size());
 		return sorted;
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
@@ -173,29 +173,32 @@ public class MelodyUtils {
 	public static Pair<Integer, Integer[]> getRandomByApproxBlockChangeAndLength(int blockChange,
 			int approx, Random melodyBlockGenerator, Integer length, int remainingVariance,
 			int remainingDirChanges) {
-		int chosenChange = blockChange + melodyBlockGenerator.nextInt(approx * 2 + 1) - approx;
-		chosenChange = OMNI.clamp(chosenChange, -7, 7);
 		//LG.d("Chosen change: " + chosenChange);
 		List<Pair<Integer, Integer[]>> viableBlocks = new ArrayList<>();
-		if (BLOCK_CHANGE_MAP.containsKey(chosenChange)) {
-			for (Pair<Integer, Integer[]> typeBlock : BLOCK_CHANGE_MAP.get(chosenChange)) {
-				Integer[] block = typeBlock.getRight();
-				if (length == null || block.length == length) {
-					viableBlocks.add(typeBlock);
+		int start = Math.max(blockChange - approx, -7);
+		int end = Math.min(blockChange + approx, 7);
+		for (int i = start; i <= end; i++) {
+			if (BLOCK_CHANGE_MAP.containsKey(i)) {
+				for (Pair<Integer, Integer[]> typeBlock : BLOCK_CHANGE_MAP.get(i)) {
+					Integer[] block = typeBlock.getRight();
+					if (length == null || block.length == length) {
+						viableBlocks.add(typeBlock);
+					}
 				}
-			}
 
-		}
-		if (BLOCK_CHANGE_MAP.containsKey(chosenChange * -1)) {
-			List<Pair<Integer, Integer[]>> invertedBlocks = new ArrayList<>();
-			for (Pair<Integer, Integer[]> typeBlock : BLOCK_CHANGE_MAP.get(chosenChange * -1)) {
-				Integer[] block = typeBlock.getRight();
-				if (length == null || block.length == length) {
-					invertedBlocks.add(Pair.of(typeBlock.getLeft(), inverse(block)));
-				}
 			}
-			viableBlocks.addAll(invertedBlocks);
+			if (BLOCK_CHANGE_MAP.containsKey(i * -1)) {
+				List<Pair<Integer, Integer[]>> invertedBlocks = new ArrayList<>();
+				for (Pair<Integer, Integer[]> typeBlock : BLOCK_CHANGE_MAP.get(i * -1)) {
+					Integer[] block = typeBlock.getRight();
+					if (length == null || block.length == length) {
+						invertedBlocks.add(Pair.of(typeBlock.getLeft(), inverse(block)));
+					}
+				}
+				viableBlocks.addAll(invertedBlocks);
+			}
 		}
+
 		//int sizeBefore = viableBlocks.size();
 		viableBlocks.removeIf(e -> MelodyUtils.variance(e.getRight()) > remainingVariance);
 		/*LG.d("Size difference: " + (sizeBefore - viableBlocks.size())

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
@@ -31,6 +31,7 @@ public class MelodyUtils {
 	public static Map<Integer, List<Pair<Integer, Integer[]>>> BLOCK_CHANGE_MAP = new HashMap<>();
 	public static Map<Integer, Set<Integer>> AVAILABLE_BLOCK_CHANGES_PER_TYPE = new HashMap<>();
 	public static List<List<Integer>> MELODY_PATTERNS = new ArrayList<>();
+	public static List<List<Integer>> SOLO_MELODY_PATTERNS = new ArrayList<>();
 
 	public static List<List<Integer>> CHORD_DIRECTIONS = new ArrayList<>();
 
@@ -67,11 +68,14 @@ public class MelodyUtils {
 		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 1, 1, 2 }));
 		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 1, 1, 1 }));
 		// inverse patterns
-		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 1, -1, 2 }));
-		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 2, -2, -1 }));
-		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 2, -1, 2 }));
-		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 2, 3, -3 }));
-		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, -1, -1, 1 }));
+		SOLO_MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 1, -1, 2 }));
+		SOLO_MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 2, -2, -1 }));
+		SOLO_MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 2, -1, 2 }));
+		SOLO_MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, -1, 2, 3 }));
+		SOLO_MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, -1, 2, 2 }));
+		SOLO_MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, -1, -1, 1 }));
+		SOLO_MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, -1, 1, 2 }));
+		MELODY_PATTERNS.addAll(SOLO_MELODY_PATTERNS);
 
 
 		// TODO: way too crazy idea - use permutations of the array presets for extreme variation (first 0 locked, the rest varies wildly)

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
@@ -34,13 +34,22 @@ public class MelodyUtils {
 
 	static {
 
-		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 0, 1, 1, -1 }));
-		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 1, -1, 1, -1 }));
-		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 1, -1, 1, -1 }));
+		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { -1, -1, 1, 2 }));
+		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { -1, 0, 0, 1 }));
+		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 0, -1, -1, 1 }));
+		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 0, -1, 1, 0 }));
+		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 0, -1, 0, 1 }));
+		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 0, -1, 1, 1 }));
+		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 0, 1, -1, 0 }));
 		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 0, 1, -1, 1 }));
-		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 1, 0, 0, -1 }));
 		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 0, 1, 1, 1 }));
-		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 0, 0, 1, -1 }));
+		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 0, 1, 1, 2 }));
+		//CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 0, 0, 1, -1 }));
+		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 0, 0, -1, 1 }));
+		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 1, -1, 1, 2 }));
+		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 1, -1, 0, 1 }));
+		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 2, 0, 1, 2 }));
+		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 2, 0, -1, 1 }));
 
 		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 2, 1, 3 }));
 		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 2, 1, 3, 1, 2, 1, 4 }));
@@ -271,6 +280,9 @@ public class MelodyUtils {
 	}
 
 	public static Integer variance(Integer[] block) {
+		// 0 4 7 2 -> variance 7 - 2 = 5
+		// 0 2 7 4 -> variance 7 - 4 = 3
+
 		int min = block[0];
 		int max = block[block.length - 1];
 		if (min > max) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
@@ -3,6 +3,7 @@ package org.vibehistorian.vibecomposer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -12,6 +13,9 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.vibehistorian.vibecomposer.MidiGenerator.Durations;
+
+import jm.music.data.Note;
 
 public class MelodyUtils {
 
@@ -496,5 +500,33 @@ public class MelodyUtils {
 					.get(altPatternIndices.get(rand.nextInt(altPatternIndices.size()))));
 		}
 		return new ArrayList<>(MELODY_PATTERNS.get(rand.nextInt(MELODY_PATTERNS.size())));
+	}
+
+	public static List<Note> sortNotesByRhythmicImportance(List<Note> notes) {
+		List<Note> sorted = new ArrayList<>();
+		List<Note> main8th = new ArrayList<>();
+		List<Note> main16th = new ArrayList<>();
+		List<Note> others = new ArrayList<>();
+
+		double currTime = 0;
+		for (Note n : notes) {
+			if (MidiUtils.isMultiple(currTime + n.getOffset(), Durations.EIGHTH_NOTE)) {
+				main8th.add(n);
+			} else if (MidiUtils.isMultiple(currTime + n.getOffset(), Durations.SIXTEENTH_NOTE)) {
+				main16th.add(n);
+			} else {
+				others.add(n);
+			}
+			currTime += n.getRhythmValue();
+		}
+		Collections.sort(main8th, Comparator.comparing(e -> e.getRhythmValue()));
+		Collections.sort(main16th, Comparator.comparing(e -> e.getRhythmValue()));
+		Collections.sort(others, Comparator.comparing(e -> e.getRhythmValue()));
+		sorted.addAll(others);
+		sorted.addAll(main16th);
+		sorted.addAll(main8th);
+		LG.i("Others: " + others.size() + ", 16th: " + main16th.size() + ", 8th: "
+				+ main8th.size());
+		return sorted;
 	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -884,7 +884,7 @@ public class MidiGenerator implements JMC {
 			int startIndex = (mp.isFillPauses())
 					? (gc.isMelodyFillPausesPerChord() ? 1 : ((chordIndex == 0) ? 1 : 0))
 					: 0;
-			LG.i("Pausing first # sorted notes: " + pausedNotes);
+			//LG.i("Pausing first # sorted notes: " + pausedNotes);
 			for (int j = 0; j < pausedNotes; j++) {
 				Note n = notes.get(j);
 				if (startIndex == 1) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -54,7 +54,6 @@ import java.util.stream.IntStream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.vibehistorian.vibecomposer.MidiUtils.ScaleMode;
-import org.vibehistorian.vibecomposer.Section.SectionType;
 import org.vibehistorian.vibecomposer.Enums.ArpPattern;
 import org.vibehistorian.vibecomposer.Enums.KeyChangeType;
 import org.vibehistorian.vibecomposer.Enums.PatternJoinMode;
@@ -2974,7 +2973,7 @@ public class MidiGenerator implements JMC {
 				gc.setArrangementPartVariationChance(normalPartVariationChance);
 			}
 
-			if (!overridden && sec.getType().equals(SectionType.BUILDUP.toString())) {
+			if (!overridden && sec.getType().toUpperCase().startsWith("BUILDUP")) {
 				if (rand.nextInt(100) < gc.getArrangementVariationChance()) {
 					List<Integer> exceptionChanceList = new ArrayList<>();
 					exceptionChanceList.add(1);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -422,8 +422,8 @@ public class MidiGenerator implements JMC {
 					}
 					blockDurationsMap.put(blockOffset, durations);
 				}
-				/*LG.d("Overall Block Durations: " + StringUtils.join(durations, ",")
-						+ ", Doubled rhythm: " + sameRhythmTwice);*/
+				LG.d("Overall Block Durations: " + StringUtils.join(durations, ",")
+						+ ", Doubled rhythm: " + sameRhythmTwice);
 				int chord1 = MidiGeneratorUtils.getStartingNote(stretchedChords,
 						blockChordNoteChoices, chordIndex, BLOCK_TARGET_MODE);
 				int chord2 = MidiGeneratorUtils.getStartingNote(stretchedChords,
@@ -446,7 +446,7 @@ public class MidiGenerator implements JMC {
 										remainingDirChanges);
 				remainingDirChanges -= blockChangesPair.getRight();
 				List<Integer> blockChanges = blockChangesPair.getLeft();
-				LG.n("Block changes: " + blockChanges);
+				LG.d("Block changes: " + blockChanges);
 				int startingNote = chord1 % 7;
 
 				List<Integer> forcedLengths = (existingPattern != null
@@ -710,13 +710,13 @@ public class MidiGenerator implements JMC {
 					for (int j = 0; j < blockDurations.size(); j++) {
 						blockDurations.set(j, arpyDuration);
 					}
-					/*LG.d("Arpy surprise for block#: " + blockNotes.size()
-							+ ", duration: " + durations.get(i));*/
+					LG.d("Arpy surprise for block#: " + blockNotes.size() + ", duration: "
+							+ durations.get(blockIndex));
 				}
 
 			}
 
-			//LG.d(StringUtils.join(blockDurations, ","));
+			LG.d("Block durations" + StringUtils.join(blockDurations, ","));
 			prevBlockType = blockType;
 			//LG.d("Block Durations size: " + blockDurations.size());
 			MelodyBlock mb = new MelodyBlock(blockNotes, blockDurations, false);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -4486,6 +4486,7 @@ public class MidiGenerator implements JMC {
 							pitch = Integer.MIN_VALUE;
 						}
 					}
+					double durMultiplier = GLOBAL_DURATION_MULTIPLIER * ip.getChordSpan();
 					if (exceptionGenerator.nextInt(100) < ip.getExceptionChance() && pitch >= 0) {
 						double splitDuration = usedDuration / 2;
 						int patternNum2 = pitchPatternSpanned.get((p + 1) % repeatedArpsPerChord);
@@ -4499,14 +4500,14 @@ public class MidiGenerator implements JMC {
 						}
 						//LG.d("Splitting arp!"); 
 						Note n1 = new Note(pitch, splitDuration, velocity);
-						n1.setDuration(splitDuration * GLOBAL_DURATION_MULTIPLIER);
+						n1.setDuration(splitDuration * durMultiplier);
 						phr.addNote(n1);
 						Note n2 = new Note(pitch2, splitDuration, Math.max(0, velocity - 15));
-						n2.setDuration(splitDuration * GLOBAL_DURATION_MULTIPLIER);
+						n2.setDuration(splitDuration * durMultiplier);
 						phr.addNote(n2);
 					} else {
 						Note n1 = new Note(pitch, usedDuration, velocity);
-						n1.setDuration(usedDuration * GLOBAL_DURATION_MULTIPLIER);
+						n1.setDuration(usedDuration * durMultiplier);
 						phr.addNote(n1);
 					}
 					durationNow += usedDuration;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -369,6 +369,12 @@ public class MidiGenerator implements JMC {
 					}
 				}
 
+				if (false) {
+					new Object() {
+
+					};
+				}
+
 				int blockOffset = blockSeedOffsets.get(chordIndex % blockSeedOffsets.size());
 				int originalBlockOffset = blockOffset;
 				blockOffset = Math.abs(blockOffset);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -3826,7 +3826,7 @@ public class MidiGenerator implements JMC {
 		if (userMelody != null) {
 			skeletonNotes = userMelody.copy().getNoteList();
 		} else {
-			if (false) {
+			if (gc.isMelodyLegacyMode()) {
 				LG.i("OLD MELODY ALGO");
 				skeletonNotes = algoGen2GenerateMelodySkeletonFromChords(ip, actualProgression,
 						generatedRootProgression, measures, notesSeedOffset, sec, variations);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -3056,9 +3056,9 @@ public class MidiGenerator implements JMC {
 		if (gc.isPartEnabled(part) && partPadding.size() > 0
 				&& trackCount < partPadding.get(part)) {
 			int tracksToPad = partPadding.get(part) - trackCount;
+			LG.i("Padding: " + part + ", #: " + tracksToPad);
 			for (int i = 0; i < tracksToPad; i++) {
 				score.add(PartExt.makeFillerPart());
-				LG.i("Padding: " + part + ", #: " + i);
 			}
 			return tracksToPad;
 		}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -2173,6 +2173,9 @@ public class MidiGenerator implements JMC {
 		for (int i = 0; i < notes.size(); i++) {
 			Note n = notes.get(i);
 			double adjDur = n.getRhythmValue();
+			if (adjDur < DBL_ERR) {
+				continue;
+			}
 			if (i > chordSeparators.get(chordSepIndex)) {
 				chordSepIndex++;
 				swingAdjust = swingUnitOfTime * (swingPercentAmount / ((double) 50.0))
@@ -4777,7 +4780,9 @@ public class MidiGenerator implements JMC {
 					gc.isTransposedNotesForceScale());
 		}
 		Mod.transpose(phr, DEFAULT_INSTRUMENT_TRANSPOSE[2] + extraTranspose + modTrans);
-
+		int hits = ip.getHitsPerPattern();
+		int swingPercentAmount = (hits % 2 == 0) ? ip.getSwingPercent() : 50;
+		swingPhrase(phr, swingPercentAmount, Durations.QUARTER_NOTE);
 
 		processSectionTransition(sec, phr.getNoteList(),
 				progressionDurations.stream().mapToDouble(e -> e).sum() * measures, 0.25, 0.15,
@@ -4846,9 +4851,6 @@ public class MidiGenerator implements JMC {
 
 		// TODO: divide
 		int repeatedArpsPerChord = ip.getHitsPerPattern() * ip.getPatternRepeat();
-		int swingPercentAmount = (repeatedArpsPerChord == 4 || repeatedArpsPerChord == 8)
-				? gc.getMaxArpSwing()
-				: 50;
 
 		/*if (melodic) {
 			repeatedArpsPerChord /= ap.getChordSpan();
@@ -5052,6 +5054,9 @@ public class MidiGenerator implements JMC {
 		processSectionTransition(sec, phr.getNoteList(),
 				progressionDurations.stream().mapToDouble(e -> e).sum() * measures, 0.25, 0.15,
 				0.9);
+
+		int hits = ip.getHitsPerPattern();
+		int swingPercentAmount = (hits % 2 == 0) ? ip.getSwingPercent() : 50;
 		swingPhrase(phr, swingPercentAmount, Durations.QUARTER_NOTE);
 		if (fillLastBeat) {
 			Mod.crescendo(phr, phr.getEndTime() * 3 / 4, phr.getEndTime(), Math.max(minVel, 55),

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -84,6 +84,7 @@ public class MidiGenerator implements JMC {
 	public static final double DBL_ERR = 0.01;
 	public static final double FILLER_NOTE_MIN_DURATION = 0.05;
 	public static double GLOBAL_DURATION_MULTIPLIER = 0.95;
+	public static double SPLIT_DURATION_MULTIPLIER = 0.97;
 	public static final int[] DEFAULT_INSTRUMENT_TRANSPOSE = { 0, -24, -12, -24, 0 };
 
 	public enum ShowScoreMode {
@@ -2934,7 +2935,7 @@ public class MidiGenerator implements JMC {
 					int noteInsertionIndex = i + addedNotes;
 
 					// |---x----------| -> |---|---------| -> old note's duration is intersection length, new note's offset is moved up by the same amount
-					double intersectionLength = intersection - currTime;
+					double intersectionLength = intersection - currTime - n.getOffset();
 					int originalPitch = n.getPitch();
 					Note splitNote = new Note(originalPitch, 0, n.getDynamic());
 					splitNote.setDuration(n.getDuration() - intersectionLength);
@@ -2977,7 +2978,7 @@ public class MidiGenerator implements JMC {
 					default:
 						break;
 					}
-					n.setDuration(intersectionLength * GLOBAL_DURATION_MULTIPLIER);
+					n.setDuration(intersectionLength * SPLIT_DURATION_MULTIPLIER);
 
 					newNotes.add(noteInsertionIndex, splitNote);
 					addedNotes++;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -483,14 +483,15 @@ public class MidiGenerator implements JMC {
 
 				int adjustment = 0;
 				int exceptionCounter = mp.getMaxNoteExceptions();
+				boolean invertedPattern = originalBlockOffset < 0;
 				for (int blockIndex = 0; blockIndex < melodyBlocks.size(); blockIndex++) {
 					MelodyBlock mb = melodyBlocks.get(blockIndex);
-					if (originalBlockOffset < 0) {
+					if (invertedPattern) {
 						mb = new MelodyBlock(MelodyUtils.inverse(mb.notes), mb.durations, true);
 					}
 					List<Integer> pitches = new ArrayList<>();
 					if (blockIndex > 0) {
-						adjustment += blockChanges.get(blockIndex - 1);
+						adjustment += blockChanges.get(blockIndex - 1) * (invertedPattern ? -1 : 1);
 					}
 					//LG.d("Adjustment: " + adjustment);
 					for (int k = 0; k < mb.durations.size(); k++) {
@@ -729,7 +730,7 @@ public class MidiGenerator implements JMC {
 			//LG.d("Block Durations size: " + blockDurations.size());
 			MelodyBlock mb = new MelodyBlock(blockNotes, blockDurations, false);
 			mbs.add(mb);
-			//LG.i("Created block: " + StringUtils.join(blockNotes, ","));
+			LG.i("Created block: " + StringUtils.join(blockNotes, ","));
 		}
 		return mbs;
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -82,7 +82,7 @@ public class MidiGenerator implements JMC {
 
 	public static final double DBL_ERR = 0.01;
 	public static final double FILLER_NOTE_MIN_DURATION = 0.05;
-	public static final double DEFAULT_DURATION_MULTIPLIER = 0.95;
+	public static double GLOBAL_DURATION_MULTIPLIER = 0.95;
 	public static final int[] DEFAULT_INSTRUMENT_TRANSPOSE = { 0, -24, -12, -24, 0 };
 
 	public enum ShowScoreMode {
@@ -568,7 +568,7 @@ public class MidiGenerator implements JMC {
 						double swingDuration = sortedDurs.get(k);
 						Note n = new Note(pitch, swingDuration, 100);
 						n.setDuration(swingDuration * (0.75 + durationGenerator.nextDouble() / 4)
-								* DEFAULT_DURATION_MULTIPLIER);
+								* GLOBAL_DURATION_MULTIPLIER);
 
 
 						noteList.add(n);
@@ -1411,7 +1411,7 @@ public class MidiGenerator implements JMC {
 					swingAdjust *= -1;
 					double swungDur = swungNote.getRhythmValue();
 					swungNote.setRhythmValue(swungDur + swingAdjust);
-					swungNote.setDuration((swungDur + swingAdjust) * DEFAULT_DURATION_MULTIPLIER);
+					swungNote.setDuration((swungDur + swingAdjust) * GLOBAL_DURATION_MULTIPLIER);
 					swingAdjust *= -1;
 					swungNote = null;
 					latestSuitableNote = null;
@@ -1452,7 +1452,7 @@ public class MidiGenerator implements JMC {
 						if (swungNote == null) {
 							latestSuitableNote.setRhythmValue(suitableDur + swingAdjust);
 							latestSuitableNote.setDuration(
-									(suitableDur + swingAdjust) * DEFAULT_DURATION_MULTIPLIER);
+									(suitableDur + swingAdjust) * GLOBAL_DURATION_MULTIPLIER);
 							swingAdjust *= -1;
 							swungNote = latestSuitableNote;
 							latestSuitableNote = null;
@@ -1461,7 +1461,7 @@ public class MidiGenerator implements JMC {
 						} else {
 							latestSuitableNote.setRhythmValue(suitableDur + swingAdjust);
 							latestSuitableNote.setDuration(
-									(suitableDur + swingAdjust) * DEFAULT_DURATION_MULTIPLIER);
+									(suitableDur + swingAdjust) * GLOBAL_DURATION_MULTIPLIER);
 							swingAdjust *= -1;
 							swungNote = null;
 							latestSuitableNote = null;
@@ -1473,7 +1473,7 @@ public class MidiGenerator implements JMC {
 							double swungDur = swungNote.getRhythmValue();
 							swungNote.setRhythmValue(swungDur + swingAdjust);
 							swungNote.setDuration(
-									(swungDur + swingAdjust) * DEFAULT_DURATION_MULTIPLIER);
+									(swungDur + swingAdjust) * GLOBAL_DURATION_MULTIPLIER);
 							swingAdjust *= -1;
 							swungNote = null;
 							latestSuitableNote = null;
@@ -1498,7 +1498,7 @@ public class MidiGenerator implements JMC {
 		if (swungNote != null) {
 			double swungDur = swungNote.getRhythmValue();
 			swungNote.setRhythmValue(swungDur + swingAdjust);
-			swungNote.setDuration((swungDur + swingAdjust) * DEFAULT_DURATION_MULTIPLIER);
+			swungNote.setDuration((swungDur + swingAdjust) * GLOBAL_DURATION_MULTIPLIER);
 			swingAdjust *= -1;
 			swungNote = null;
 			latestSuitableNote = null;
@@ -2016,7 +2016,7 @@ public class MidiGenerator implements JMC {
 					double swingDuration = durations.get(j);
 					Note n = new Note(pitch, swingDuration, 100);
 					n.setDuration(swingDuration * (0.75 + durationGenerator.nextDouble() / 4)
-							* DEFAULT_DURATION_MULTIPLIER);
+							* GLOBAL_DURATION_MULTIPLIER);
 
 					if (hasSingleNoteException && gc.isMelodySingleNoteExceptions()) {
 						if (tempChangedDir) {
@@ -3762,8 +3762,9 @@ public class MidiGenerator implements JMC {
 										: squishedChords.get(chordIndex)[randomNote];
 
 						int velocity = bassDynamics.nextInt(velSpace) + minVel;
-
-						phr.addNote(new Note(pitch, dur, velocity));
+						Note n = new Note(pitch, dur, velocity);
+						n.setDuration(dur * GLOBAL_DURATION_MULTIPLIER);
+						phr.addNote(n);
 						counter++;
 					}
 				} else {
@@ -3881,7 +3882,7 @@ public class MidiGenerator implements JMC {
 											: squishedChords.get(chordIndex)[randomNote];
 						}
 						Note n = new Note(pitch, duration, velocity);
-						n.setDuration(finalDuration * DEFAULT_DURATION_MULTIPLIER);
+						n.setDuration(finalDuration * GLOBAL_DURATION_MULTIPLIER);
 						phr.addNote(n);
 
 						durationNow += duration;
@@ -4496,11 +4497,17 @@ public class MidiGenerator implements JMC {
 						} else {
 							pitch2 = pitch;
 						}
-						//LG.d("Splitting arp!");
-						phr.addNote(new Note(pitch, splitDuration, velocity));
-						phr.addNote(new Note(pitch2, splitDuration, Math.max(0, velocity - 15)));
+						//LG.d("Splitting arp!"); 
+						Note n1 = new Note(pitch, splitDuration, velocity);
+						n1.setDuration(splitDuration * GLOBAL_DURATION_MULTIPLIER);
+						phr.addNote(n1);
+						Note n2 = new Note(pitch2, splitDuration, Math.max(0, velocity - 15));
+						n2.setDuration(splitDuration * GLOBAL_DURATION_MULTIPLIER);
+						phr.addNote(n2);
 					} else {
-						phr.addNote(new Note(pitch, usedDuration, velocity));
+						Note n1 = new Note(pitch, usedDuration, velocity);
+						n1.setDuration(usedDuration * GLOBAL_DURATION_MULTIPLIER);
+						phr.addNote(n1);
 					}
 					durationNow += usedDuration;
 					p = (p + 1) % repeatedArpsPerChord;
@@ -4709,13 +4716,13 @@ public class MidiGenerator implements JMC {
 						int secondVelocity = (velocity * 8) / 10;
 						Note n1 = new Note(pitch, usedDrumDuration / 2, velocity);
 						Note n2 = new Note(pitch, usedDrumDuration / 2, secondVelocity);
-						n1.setDuration(0.5 * n1.getRhythmValue());
-						n2.setDuration(0.5 * n2.getRhythmValue());
+						n1.setDuration(0.5 * n1.getRhythmValue() * GLOBAL_DURATION_MULTIPLIER);
+						n2.setDuration(0.5 * n2.getRhythmValue() * GLOBAL_DURATION_MULTIPLIER);
 						phr.addNote(n1);
 						phr.addNote(n2);
 					} else {
 						Note n1 = new Note(pitch, usedDrumDuration, velocity);
-						n1.setDuration(0.5 * n1.getRhythmValue());
+						n1.setDuration(0.5 * n1.getRhythmValue() * GLOBAL_DURATION_MULTIPLIER);
 						phr.addNote(n1);
 					}
 					durationNow += usedDrumDuration;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -2515,6 +2515,7 @@ public class MidiGenerator implements JMC {
 					rootProgression = generatedRootProgression;
 					chordProgression = actualProgression;
 					progressionDurations = actualDurations;
+					sec.setDisplayAlternateChords(false);
 
 				}
 			} else if (rootProgression.size() == generatedRootProgression.size()) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -3951,7 +3951,7 @@ public class MidiGenerator implements JMC {
 			Mod.transpose(phr, modTrans + extraTranspose);
 		}
 		phr.setStartTime(START_TIME_DELAY);
-		addOffsetsToPhrase(phr, ip.getDelay());
+		addOffsetsToPhrase(phr, ip);
 		return phr;
 	}
 
@@ -4227,7 +4227,7 @@ public class MidiGenerator implements JMC {
 		}
 		Mod.transpose(phr, DEFAULT_INSTRUMENT_TRANSPOSE[1] + ip.getTranspose() + modTrans);
 		phr.setStartTime(START_TIME_DELAY);
-		addOffsetsToPhrase(phr, ip.getDelay());
+		addOffsetsToPhrase(phr, ip);
 		if (genVars && variations != null) {
 			sec.setVariation(1, 0, variations);
 		}
@@ -4600,17 +4600,21 @@ public class MidiGenerator implements JMC {
 
 		// delay
 		phr.setStartTime(START_TIME_DELAY);
-		addOffsetsToPhrase(phr, ip.getDelay());
+		addOffsetsToPhrase(phr, ip);
 		return phr;
 	}
 
-	private static void addOffsetsToPhrase(Phrase phr, int delay) {
-		if (delay != 0) {
-			double offsetDelay = (noteMultiplier * delay) / 1000.0;
+	private static void addOffsetsToPhrase(Phrase phr, InstPart ip) {
+		if (ip.getDelay() != 0) {
+			double offsetDelay = (noteMultiplier * ip.getDelay()) / 1000.0;
 			for (Object no : phr.getNoteList()) {
 				Note n = (Note) no;
 				n.setOffset(n.getOffset() + offsetDelay);
 			}
+		}
+		if (ip.getFeedbackCount() > 0) {
+			MidiGeneratorUtils.multiDelayPhrase(phr, ip.getFeedbackCount(),
+					ip.getFeedbackDuration() / 1000.0, ip.getFeedbackVol() / 100.0);
 		}
 	}
 
@@ -4887,7 +4891,7 @@ public class MidiGenerator implements JMC {
 		ip.setHitsPerPattern(apClone.getHitsPerPattern());
 		ip.setPatternRepeat(apClone.getPatternRepeat());
 		phr.setStartTime(START_TIME_DELAY);
-		addOffsetsToPhrase(phr, ip.getDelay());
+		addOffsetsToPhrase(phr, ip);
 		//MidiGeneratorUtils.multiDelayPhrase(phr, 2, Durations.DOTTED_EIGHTH_NOTE);
 		return phr;
 	}
@@ -4914,7 +4918,7 @@ public class MidiGenerator implements JMC {
 		if (!ip.isVelocityPattern() && drumPattern.indexOf(ip.getInstrument()) == -1) {
 			//drumPhrase.addNote(new Note(Integer.MIN_VALUE, patternDurationTotal, 100));
 			phr.setStartTime(START_TIME_DELAY);
-			addOffsetsToPhrase(phr, ip.getDelay());
+			addOffsetsToPhrase(phr, ip);
 			return phr;
 		}
 
@@ -5080,7 +5084,7 @@ public class MidiGenerator implements JMC {
 
 		swingPhrase(phr, swingPercentAmount, Durations.QUARTER_NOTE);
 		phr.setStartTime(START_TIME_DELAY);
-		addOffsetsToPhrase(phr, ip.getDelay());
+		addOffsetsToPhrase(phr, ip);
 		ip.setHitsPerPattern(dpClone.getHitsPerPattern());
 		ip.setPatternShift(dpClone.getPatternShift());
 		ip.setChordSpan(dpClone.getChordSpan());

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -4888,6 +4888,7 @@ public class MidiGenerator implements JMC {
 		ip.setPatternRepeat(apClone.getPatternRepeat());
 		phr.setStartTime(START_TIME_DELAY);
 		addOffsetsToPhrase(phr, ip.getDelay());
+		//MidiGeneratorUtils.multiDelayPhrase(phr, 2, Durations.DOTTED_EIGHTH_NOTE);
 		return phr;
 	}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -2944,15 +2944,35 @@ public class MidiGenerator implements JMC {
 						splitNote.setPitch(Note.REST);
 						break;
 					case 1:
-						// chord notes
-						int newPitchOrder = sortedPitches.indexOf(originalPitch % 12) + 1;
-						int pitchAdd = (newPitchOrder < sortedPitches.size())
-								? sortedPitches.get(newPitchOrder)
+						int newPitchOrderUp = sortedPitches.indexOf(originalPitch % 12) + 1;
+						int pitchAdd = (newPitchOrderUp < sortedPitches.size())
+								? sortedPitches.get(newPitchOrderUp)
 								: (sortedPitches.get(0) + 12);
 						splitNote.setPitch(MidiUtils.octavePitch(originalPitch) + pitchAdd);
 						break;
 					case 2:
-						splitNote.setDynamic((int) Math.min(126, n.getDynamic() * 1.5));
+						int newPitchOrderDown = sortedPitches.indexOf(originalPitch % 12) - 1;
+						int pitchSubtract = (newPitchOrderDown >= 0)
+								? sortedPitches.get(newPitchOrderDown)
+								: (sortedPitches.get(sortedPitches.size() - 1) - 12);
+						splitNote.setPitch(MidiUtils.octavePitch(originalPitch) + pitchSubtract);
+						break;
+					case 3:
+						int newPitchOrder = sortedPitches.indexOf(originalPitch % 12)
+								+ (accentGenerator.nextBoolean() ? 1 : -1);
+						int pitchAdjustment = (newPitchOrder >= 0
+								&& newPitchOrder < sortedPitches.size())
+										? sortedPitches.get(newPitchOrder)
+										: (newPitchOrder < 0
+												? (sortedPitches.get(sortedPitches.size() - 1) - 12)
+												: (sortedPitches.get(0) + 12));
+						splitNote.setPitch(MidiUtils.octavePitch(originalPitch) + pitchAdjustment);
+						break;
+					case 4:
+						splitNote.setDynamic((int) Math.min(126, n.getDynamic() * 1.25));
+						break;
+					case 5:
+						splitNote.setDynamic((int) Math.min(126, n.getDynamic() * 0.75));
 						break;
 					default:
 						break;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -5018,8 +5018,8 @@ public class MidiGenerator implements JMC {
 			arpPausesPattern = arpPausesPattern.subList(0, ap.getHitsPerPattern());
 		}
 
-		List<Integer> arpPattern = makeRandomArpPattern(ap.getHitsPerPattern(),
-				ap.isRepeatableNotes(), uiGenerator2arpPattern);
+		List<Integer> arpPattern = makeRandomArpPattern(ap.getHitsPerPattern(), true,
+				uiGenerator2arpPattern);
 		arpOctavePattern = arpOctavePattern.subList(0, ap.getHitsPerPattern());
 
 		Collections.rotate(arpPattern, -1 * ap.getArpPatternRotate());

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -59,6 +59,7 @@ import org.vibehistorian.vibecomposer.Enums.KeyChangeType;
 import org.vibehistorian.vibecomposer.Enums.PatternJoinMode;
 import org.vibehistorian.vibecomposer.Enums.RhythmPattern;
 import org.vibehistorian.vibecomposer.Helpers.PartExt;
+import org.vibehistorian.vibecomposer.Helpers.PhraseExt;
 import org.vibehistorian.vibecomposer.Helpers.PhraseNote;
 import org.vibehistorian.vibecomposer.Helpers.PhraseNotes;
 import org.vibehistorian.vibecomposer.Panels.DrumGenSettings;
@@ -230,6 +231,7 @@ public class MidiGenerator implements JMC {
 
 	private int samePitchCount = 0;
 	private int previousPitch = 0;
+	private int secOrder = -1;
 
 	private int modTrans = 0;
 	private ScaleMode modScale = null;
@@ -2932,9 +2934,8 @@ public class MidiGenerator implements JMC {
 		boolean isPreview = arr.getSections().size() == 1;
 		LG.i("Arrangement - MANUAL? " + overridden);
 		int arrSeed = (arr.getSeed() != 0) ? arr.getSeed() : mainGeneratorSeed;
-
+		secOrder = -1;
 		int normalPartVariationChance = gc.getArrangementPartVariationChance();
-		int secOrder = -1;
 
 		storeGlobalParts();
 
@@ -3451,7 +3452,7 @@ public class MidiGenerator implements JMC {
 					copiedPhrases.add(m);
 				} else {
 					Note emptyMeasureNote = new Note(Integer.MIN_VALUE, measureLength);
-					Phrase emptyPhrase = new Phrase();
+					Phrase emptyPhrase = new PhraseExt(0, i, secOrder);
 					emptyPhrase.setStartTime(START_TIME_DELAY);
 					emptyPhrase.add(emptyMeasureNote);
 					copiedPhrases.add(emptyPhrase.copy());
@@ -3466,7 +3467,7 @@ public class MidiGenerator implements JMC {
 			double measureLength) {
 		// copied into empty sections
 		Note emptyMeasureNote = new Note(Integer.MIN_VALUE, measureLength);
-		Phrase emptyPhrase = new Phrase();
+		Phrase emptyPhrase = new PhraseExt();
 		emptyPhrase.setStartTime(START_TIME_DELAY);
 		emptyPhrase.add(emptyMeasureNote);
 
@@ -4012,7 +4013,7 @@ public class MidiGenerator implements JMC {
 			List<int[]> generatedRootProgression, int notesSeedOffset, Section sec,
 			List<Integer> variations) {
 		LG.d("Processing: " + ip.partInfo());
-		Phrase phr = new Phrase();
+		Phrase phr = new PhraseExt(0, ip.getAbsoluteOrder(), secOrder);
 
 		int measures = sec.getMeasures();
 
@@ -4164,7 +4165,7 @@ public class MidiGenerator implements JMC {
 
 		int seed = ip.getPatternSeedWithPartOffset();
 
-		Phrase phr = new Phrase();
+		Phrase phr = new PhraseExt(1, ip.getAbsoluteOrder(), secOrder);
 		int volMultiplier = (gc.isScaleMidiVelocityInArrangement()) ? sec.getVol(1) : 100;
 		int minVel = multiplyVelocity(ip.getVelocityMin(), volMultiplier, 0, 1);
 		int maxVel = multiplyVelocity(ip.getVelocityMax(), volMultiplier, 1, 0);
@@ -4433,7 +4434,7 @@ public class MidiGenerator implements JMC {
 		int measures = sec.getMeasures();
 
 		int orderSeed = ip.getPatternSeedWithPartOffset() + ip.getOrder();
-		Phrase phr = new Phrase();
+		Phrase phr = new PhraseExt(2, ip.getAbsoluteOrder(), secOrder);
 		List<Chord> chords = new ArrayList<>();
 		Random variationGenerator = new Random(
 				gc.getArrangement().getSeed() + ip.getOrder() + sec.getTypeSeedOffset());
@@ -4823,7 +4824,7 @@ public class MidiGenerator implements JMC {
 
 		int measures = sec.getMeasures();
 
-		Phrase phr = new Phrase();
+		Phrase phr = new PhraseExt(3, ip.getAbsoluteOrder(), secOrder);
 
 		ArpPart apClone = (ArpPart) ip.clone();
 		int seed = ip.getPatternSeedWithPartOffset() + ip.getOrder();
@@ -5080,7 +5081,7 @@ public class MidiGenerator implements JMC {
 
 		int measures = sec.getMeasures();
 
-		Phrase phr = new Phrase();
+		Phrase phr = new PhraseExt(4, ip.getAbsoluteOrder(), secOrder);
 
 		DrumPart dpClone = (DrumPart) ip.clone();
 		boolean kicky = ip.getInstrument() < 38;
@@ -5387,7 +5388,7 @@ public class MidiGenerator implements JMC {
 	}
 
 	public Phrase fillChordSlash(List<int[]> actualProgression, int measures) {
-		Phrase chordSlashPhrase = new Phrase();
+		Phrase chordSlashPhrase = new PhraseExt(2, 0, secOrder);
 		Random chordSlashGenerator = new Random(gc.getRandomSeed() + 2);
 		for (int i = 0; i < measures; i++) {
 			// fill slash chord slashes

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -4665,9 +4665,6 @@ public class MidiGenerator implements JMC {
 						}
 
 					}
-					if (pitch != Integer.MIN_VALUE && gc.isDrumCustomMapping()) {
-						pitch = mapDrumPitchByCustomMapping(pitch, true);
-					}
 					boolean exception = exceptionGenerator.nextInt(100) < (ip.getExceptionChance()
 							+ extraExceptionChance + drumFillExceptionChance);
 
@@ -4702,6 +4699,16 @@ public class MidiGenerator implements JMC {
 
 		if (!overwriteWithCustomSectionMidi(sec, phr, ip)) {
 			addPhraseNotesToSection(sec, ip, phr.getNoteList());
+		}
+		if (gc.isDrumCustomMapping()) {
+			for (Object o : phr.getNoteList()) {
+				Note n = (Note) o;
+				int pitch = n.getPitch();
+				if (pitch >= 0) {
+					pitch = mapDrumPitchByCustomMapping(n.getPitch(), true);
+					n.setPitch(pitch);
+				}
+			}
 		}
 
 		MidiGeneratorUtils.processSectionTransition(sec, phr.getNoteList(),
@@ -5059,7 +5066,7 @@ public class MidiGenerator implements JMC {
 			} else {
 				if (dp.getInstrument() == 42
 						&& uiGenerator1drumPattern.nextInt(100) < OPENHAT_CHANCE) {
-					drumPattern.add(mapDrumPitchByCustomMapping(46, true));
+					drumPattern.add(46);
 				} else {
 					drumPattern.add(dp.getInstrument());
 				}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -1072,6 +1072,25 @@ public class MidiGenerator implements JMC {
 			}
 		});
 
+		if (sec.getVariation(0, mp.getAbsoluteOrder()).contains(Integer.valueOf(3))) {
+			double currRv = 0;
+			for (int chordIndex = 0; chordIndex < fullMelodyMap.keySet().size(); chordIndex++) {
+				List<Note> notes = fullMelodyMap.get(chordIndex);
+				for (Note n : notes) {
+					double noteStart = currRv + n.getOffset();
+					double noteEnd = noteStart + n.getDuration();
+
+					double closestEndOnGrid = Math.floor(noteEnd / Durations.EIGHTH_NOTE)
+							* Durations.EIGHTH_NOTE;
+					if (closestEndOnGrid > (noteStart + Durations.SIXTEENTH_NOTE / 2)) {
+						n.setDuration(closestEndOnGrid - noteStart);
+					}
+
+
+				}
+			}
+		}
+
 		return fullMelodyMap;
 	}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -729,6 +729,7 @@ public class MidiGenerator implements JMC {
 			//LG.d("Block Durations size: " + blockDurations.size());
 			MelodyBlock mb = new MelodyBlock(blockNotes, blockDurations, false);
 			mbs.add(mb);
+			//LG.i("Created block: " + StringUtils.join(blockNotes, ","));
 		}
 		return mbs;
 	}
@@ -4265,7 +4266,7 @@ public class MidiGenerator implements JMC {
 					}
 				}
 
-				flamGenerator.setSeed(orderSeed + 30 + (chordIndex % 2));
+				flamGenerator.setSeed(orderSeed + 30 + (chordIndex % 4));
 				Chord c = Chord.EMPTY(progressionDurations.get(chordIndex));
 				if (!ignoreChordSpanFill) {
 					if (fillPattern.get(chordIndex) < 1) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -874,8 +874,9 @@ public class MidiGenerator implements JMC {
 
 		// pause by %, sort not-paused into pitches
 		for (int chordIndex = 0; chordIndex < fullMelodyMap.keySet().size(); chordIndex++) {
-			List<Note> notes = new ArrayList<>(fullMelodyMap.get(chordIndex));
-			Collections.sort(notes, Comparator.comparing(e -> e.getRhythmValue()));
+			List<Note> notes = MelodyUtils
+					.sortNotesByRhythmicImportance(fullMelodyMap.get(chordIndex));
+			//Collections.sort(notes, Comparator.comparing(e -> e.getRhythmValue()));
 			pauseGenerator.setSeed(orderSeed + 5);
 			int actualPauseChance = MidiGeneratorUtils.adjustChanceParamForTransition(
 					mp.getPauseChance(), sec, chordIndex, durations.size(), 40, 0.25, false);
@@ -883,7 +884,7 @@ public class MidiGenerator implements JMC {
 			int startIndex = (mp.isFillPauses())
 					? (gc.isMelodyFillPausesPerChord() ? 1 : ((chordIndex == 0) ? 1 : 0))
 					: 0;
-
+			LG.i("Pausing first # sorted notes: " + pausedNotes);
 			for (int j = 0; j < pausedNotes; j++) {
 				Note n = notes.get(j);
 				if (startIndex == 1) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
@@ -21,13 +21,13 @@ public class MidiGeneratorUtils {
 		Random rand = new Random(randomSeed);
 		List<Integer> dirs = new ArrayList<>();
 		dirs.add(0);
-		int last = roots ? progression.get(0)[0]
+		int current = roots ? progression.get(0)[0]
 				: progression.get(0)[rand.nextInt(progression.get(0).length)];
 		for (int i = 1; i < progression.size(); i++) {
 			int next = roots ? progression.get(i)[0]
 					: progression.get(i)[rand.nextInt(progression.get(i).length)];
-			dirs.add(Integer.compare(next, last));
-			last = next;
+			dirs.add(Integer.compare(next, current));
+			current = next;
 		}
 		return dirs;
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
@@ -1,0 +1,570 @@
+package org.vibehistorian.vibecomposer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.vibehistorian.vibecomposer.MidiGenerator.Durations;
+import org.vibehistorian.vibecomposer.MidiUtils.ScaleMode;
+
+import jm.music.data.Note;
+
+public class MidiGeneratorUtils {
+
+	static List<Integer> generateMelodyOffsetDirectionsFromChordProgression(
+			List<int[]> progression, boolean roots, int randomSeed) {
+		Random rand = new Random(randomSeed);
+		List<Integer> dirs = new ArrayList<>();
+		dirs.add(0);
+		int last = roots ? progression.get(0)[0]
+				: progression.get(0)[rand.nextInt(progression.get(0).length)];
+		for (int i = 1; i < progression.size(); i++) {
+			int next = roots ? progression.get(i)[0]
+					: progression.get(i)[rand.nextInt(progression.get(i).length)];
+			dirs.add(Integer.compare(next, last));
+			last = next;
+		}
+		return dirs;
+	}
+
+	static List<Integer> randomizedChordDirections(int chords, int randomSeed) {
+		Random rand = new Random(randomSeed);
+	
+		List<Integer> chordDirs = new ArrayList<>(MelodyUtils.CHORD_DIRECTIONS
+				.get(rand.nextInt(MelodyUtils.CHORD_DIRECTIONS.size())));
+		while (chordDirs.size() < chords) {
+			chordDirs.addAll(chordDirs);
+		}
+		chordDirs = chordDirs.subList(0, chords);
+		return chordDirs;
+		/*
+		List<Integer> dirs = new ArrayList<>();
+		//dirs.add(0);
+		for (int i = 0; i < chords; i++) {
+			dirs.add(rand.nextInt(3) - 1);
+		}
+		return dirs;*/
+	}
+
+	static List<Integer> convertRootsToOffsets(List<Integer> roots, int targetMode) {
+		List<Integer> offsets = new ArrayList<>();
+		for (int i = 0; i < roots.size(); i++) {
+			int value = -1 * roots.get(i);
+			if (targetMode == 0) {
+				value /= 2;
+			}
+			offsets.add(value);
+		}
+		return offsets;
+	}
+
+	static List<Integer> multipliedDirections(List<Integer> directions, int randomSeed,
+			int targetNoteVariation) {
+		if (targetNoteVariation < 1) {
+			targetNoteVariation = 1;
+		}
+		Random rand = new Random(randomSeed);
+		List<Integer> multiDirs = new ArrayList<>();
+		for (Integer o : directions) {
+			int multiplied = (rand.nextInt(targetNoteVariation) + 1) * o;
+			if (o < 0) {
+				// small correction for too low dips
+				multiplied++;
+			}
+			multiDirs.add(multiplied);
+		}
+		return multiDirs;
+	}
+
+	static List<Integer> getRootIndexes(List<int[]> chords) {
+		List<Integer> rootIndexes = new ArrayList<>();
+		for (int i = 0; i < chords.size(); i++) {
+			int root = chords.get(i)[0];
+			int rootIndex = MidiUtils.MAJ_SCALE.indexOf(root % 12);
+			if (rootIndex < 0) {
+				int closestPitch = MidiUtils.getClosestFromList(MidiUtils.MAJ_SCALE, root % 12);
+				rootIndex = MidiUtils.MAJ_SCALE.indexOf(closestPitch % 12);
+			}
+			rootIndexes.add(rootIndex);
+		}
+		return rootIndexes;
+	}
+
+	public static int adjustChanceParamForTransition(int param, Section sec, int chordNum,
+			int chordSize, int maxEffect, double affectedMeasure, boolean reverseEffect) {
+		if (chordSize < 2 || !sec.isTransition()) {
+			return param;
+		}
+	
+		int minAffectedChord = OMNI.clamp((int) (affectedMeasure * chordSize) - 1, 1,
+				chordSize - 1);
+		//LG.d("Min affected: " + minAffectedChord);
+		if (chordNum < minAffectedChord) {
+			return param;
+		}
+		//LG.d("Old param: " + param);
+	
+		int chordRange = chordSize - 1 - minAffectedChord;
+		double effect = (chordRange > 0) ? ((chordNum - minAffectedChord) / ((double) chordRange))
+				: 1.0;
+	
+		int transitionType = sec.getTransitionType();
+	
+		int multiplier = reverseEffect ? -1 : 1;
+		if (transitionType == 1) {
+			param += maxEffect * effect * multiplier;
+		} else {
+			param -= maxEffect * effect * multiplier;
+		}
+		param = OMNI.clampChance(param);
+		//LG.d("New param: " + param);
+		return param;
+	}
+
+	static Map<Integer, List<Integer>> getChordNoteChoicesFromChords(List<int[]> chords) {
+		Map<Integer, List<Integer>> choiceMap = new HashMap<>();
+		int counter = 0;
+		for (int[] c : chords) {
+			List<Integer> choices = new ArrayList<>();
+			for (int pitch : c) {
+				int index = MidiUtils.MAJ_SCALE.indexOf(pitch % 12);
+				if (index >= 0) {
+					choices.add(index);
+					choices.add(index - 7);
+				}
+			}
+			choiceMap.put(counter++, choices);
+		}
+		return choiceMap;
+	}
+
+	public static List<Integer> generateOffsets(List<String> chordStrings, int randomSeed,
+			int targetMode, int targetNoteVariation, Boolean isPublic) {
+		List<int[]> chords = new ArrayList<>();
+		for (int i = 0; i < chordStrings.size(); i++) {
+			chords.add(MidiUtils.mappedChord(chordStrings.get(i)));
+		}
+		return MidiGeneratorUtils.generateOffsets(chords, randomSeed, targetMode, targetNoteVariation);
+	}
+
+	static Pair<Integer, Integer> normalizeNotePitch(int startingNote, int startingPitch) {
+		if (startingNote >= 7) {
+			int divided = startingNote / 7;
+			startingPitch += (12 * divided);
+			startingNote -= (7 * divided);
+		} else if (startingNote < 0) {
+			int divided = 1 + ((-1 * (startingNote + 1)) / 7);
+			startingPitch -= (12 * divided);
+			startingNote += (7 * divided);
+		}
+		return Pair.of(startingNote, startingPitch);
+	}
+
+	static List<Integer> generateOffsets(List<int[]> chords, int randomSeed, int targetMode,
+			int targetNoteVariation) {
+		List<Integer> chordOffsets = convertRootsToOffsets(getRootIndexes(chords), targetMode);
+		List<Integer> multipliedDirections = multipliedDirections(
+				MidiGenerator.gc != null && MidiGenerator.gc.isMelodyUseDirectionsFromProgression()
+						? generateMelodyOffsetDirectionsFromChordProgression(
+								chords, true, randomSeed)
+						: randomizedChordDirections(chords.size(), randomSeed),
+				randomSeed + 1, targetNoteVariation);
+		List<Integer> offsets = new ArrayList<>();
+		for (int i = 0; i < chordOffsets.size(); i++) {
+			/*LG.d("Chord offset: " + chordOffsets.get(i) + ", multiDir: "
+					+ multipliedDirections.get(i));*/
+			if (targetMode == 1) {
+				offsets.add(chordOffsets.get(i) + multipliedDirections.get(i));
+			} else {
+				offsets.add(multipliedDirections.get(i));
+			}
+	
+		}
+		if (targetMode >= 1) {
+			Map<Integer, List<Integer>> choiceMap = getChordNoteChoicesFromChords(chords);
+			for (int i = 0; i < chordOffsets.size(); i++) {
+				List<Integer> choices = choiceMap.get(i);
+				int offset = (targetMode == 1) ? offsets.get(i) - chordOffsets.get(i)
+						: offsets.get(i);
+				int chordTargetNote = MidiUtils.getClosestFromList(choices, offset);
+				LG.n("Offset old: " + offset + ", C T NOte: " + chordTargetNote);
+				offsets.set(i, (targetMode == 1) ? chordTargetNote + chordOffsets.get(i)
+						: chordTargetNote);
+			}
+			if (targetMode == 2) {
+				int last = offsets.get(offsets.size() - 1);
+				if (offsets.size() > 3 && (last == offsets.get(offsets.size() - 3))) {
+					last += (new Random(randomSeed).nextBoolean() ? 2 : -2);
+					offsets.set(offsets.size() - 1,
+							MidiUtils.getClosestFromList(choiceMap.get(offsets.size() - 1), last));
+					LG.d("Last offset moved!");
+				}
+			}
+		} else {
+			int last = offsets.get(offsets.size() - 1);
+			if (offsets.size() > 3 && (last == offsets.get(offsets.size() - 3))) {
+				last += (new Random(randomSeed).nextBoolean() ? 1 : -1);
+				offsets.set(offsets.size() - 1, last);
+			}
+		}
+	
+		//int min = offsets.stream().min((e1, e2) -> e1.compareTo(e2)).get();
+		/*if (min == -1) {
+			for (int i = 0; i < offsets.size(); i++) {
+				offsets.set(i, offsets.get(i) + 1);
+			}
+		}*/
+	
+		LG.d("RANDOMIZED OFFSETS");
+		return offsets;
+	}
+
+	static List<Boolean> generateMelodyDirectionsFromChordProgression(
+			List<int[]> progression, boolean roots) {
+	
+		List<Boolean> ascDirectionList = new ArrayList<>();
+	
+		for (int i = 0; i < progression.size(); i++) {
+			if (roots) {
+				int current = progression.get(i)[0];
+				int next = progression.get((i + 1) % progression.size())[0];
+				ascDirectionList.add(Boolean.valueOf(current <= next));
+			} else {
+				int current = progression.get(i)[progression.get(i).length - 1];
+				int next = progression.get((i + 1)
+						% progression.size())[progression.get((i + 1) % progression.size()).length
+								- 1];
+				ascDirectionList.add(Boolean.valueOf(current <= next));
+			}
+	
+		}
+	
+		return ascDirectionList;
+	}
+
+	static List<Double> generateMelodyDirectionChordDividers(int chords, Random dirGen) {
+		List<Double> map = new ArrayList<>();
+		for (int i = 0; i < chords; i++) {
+			double divider = dirGen.nextDouble() * 0.80 + 0.20;
+			map.add(divider);
+	
+		}
+		return map;
+	}
+
+	public static boolean isDottedNote(double note) {
+		if (MidiUtils.roughlyEqual(MidiGenerator.Durations.DOTTED_QUARTER_NOTE, note))
+			return true;
+		if (MidiUtils.roughlyEqual(MidiGenerator.Durations.DOTTED_WHOLE_NOTE, note))
+			return true;
+		if (MidiUtils.roughlyEqual(MidiGenerator.Durations.DOTTED_HALF_NOTE, note))
+			return true;
+		if (MidiUtils.roughlyEqual(MidiGenerator.Durations.DOTTED_EIGHTH_NOTE, note))
+			return true;
+		if (MidiUtils.roughlyEqual(MidiGenerator.Durations.DOTTED_SIXTEENTH_NOTE, note))
+			return true;
+		return false;
+	}
+
+	public static int getAllowedPitchFromRange(int min, int max, double posInChord,
+			Random splitNoteGen) {
+	
+		boolean allowBs = posInChord > 0.66;
+		//LG.i("Min: " + min + ", max: " + max);
+		int normMin = min % 12;
+		int normMax = max % 12;
+		if (normMax <= normMin) {
+			normMax += 12;
+		}
+	
+		List<Integer> allowedPitches = new ArrayList<>(MidiUtils.MAJ_SCALE);
+		int allowedPitchSize = allowedPitches.size();
+		for (int i = 0; i < allowedPitchSize; i++) {
+	
+			allowedPitches.add(allowedPitches.get(i) + 12);
+		}
+		//LG.i("Size: " + allowedPitches.size());
+		final int finalNormMax = normMax;
+		//LG.i("Contents: " + StringUtils.join(allowedPitches, ", "));
+		allowedPitches.removeIf(e -> !(normMin <= e && e <= finalNormMax));
+		if (!allowBs) {
+			allowedPitches.remove(Integer.valueOf(11));
+			allowedPitches.remove(Integer.valueOf(23));
+		}
+		//LG.i("Contents: " + StringUtils.join(allowedPitches, ", "));
+		int normReturnPitch = allowedPitches.get(splitNoteGen.nextInt(allowedPitches.size()));
+		//LG.i("Return n: " + normReturnPitch);
+		while (normReturnPitch < min) {
+			normReturnPitch += 12;
+		}
+		return normReturnPitch;
+	}
+
+	private static boolean fits(int pitch, int min, int max, boolean isInclusive) {
+		if (isInclusive) {
+			if (pitch >= min && pitch <= max) {
+				return true;
+			} else {
+				return false;
+			}
+		} else {
+			if (pitch > min && pitch < max) {
+				return true;
+			} else {
+				return false;
+			}
+		}
+	}
+
+	public static List<Double> getSustainedDurationsFromPattern(List<Integer> pattern,
+			double addDur) {
+		List<Double> durations = new ArrayList<>();
+		double dur = 0;
+		int end = pattern.size();
+		for (int i = 0; i < end; i++) {
+			if (pattern.get(i) < 1) {
+				dur += addDur;
+			} else {
+				dur = addDur;
+			}
+			if (i < end - 1 && pattern.get(i + 1) == 1) {
+				durations.add(dur);
+			}
+		}
+		durations.add(dur);
+	
+		return durations;
+	}
+
+	public static int multiplyVelocity(int velocity, int multiplierPercentage, int maxAdjust,
+			int minAdjust) {
+		if (multiplierPercentage == 100) {
+			return velocity;
+		} else if (multiplierPercentage > 100) {
+			return Math.min(127 - maxAdjust, velocity * multiplierPercentage / 100);
+		} else {
+			return Math.max(0 + minAdjust, velocity * multiplierPercentage / 100);
+		}
+	}
+
+	static int getStartingNote(List<int[]> stretchedChords,
+			List<Integer> blockChordNoteChoices, int chordNum, int BLOCK_TARGET_MODE) {
+	
+		int chordNumIndex = chordNum % stretchedChords.size();
+		int chordNoteChoiceIndex = (BLOCK_TARGET_MODE == 2
+				&& chordNum == blockChordNoteChoices.size()) ? (chordNum - 1)
+						: (chordNum % blockChordNoteChoices.size());
+		int[] chord = stretchedChords.get(chordNumIndex);
+	
+		int startingPitch = (BLOCK_TARGET_MODE == 0)
+				? MidiUtils.getXthChordNote(blockChordNoteChoices.get(chordNoteChoiceIndex), chord)
+				: ((BLOCK_TARGET_MODE == 1) ? chord[0] : (5 * 12));
+		int startingOct = startingPitch / 12;
+		int startingNote = MidiUtils.MAJ_SCALE.indexOf(startingPitch % 12);
+		if (startingNote < 0) {
+			throw new IllegalArgumentException("BAD STARTING NOTE!");
+		}
+		return startingNote + startingOct * 7
+				+ ((BLOCK_TARGET_MODE > 0) ? blockChordNoteChoices.get(chordNoteChoiceIndex) : 0);
+	}
+
+	static void applyNoteLengthMultiplier(List<Note> notes, int noteLengthMultiplier) {
+		if (noteLengthMultiplier == 100) {
+			return;
+		}
+		boolean avoidSamePitchCollision = true;
+		List<Pair<Double, Note>> sn = JMusicUtilsCustom.makeNoteStartTimes(notes);
+		for (int i = 0; i < sn.size(); i++) {
+			Note n = sn.get(i).getRight();
+			double duration = n.getDuration() * noteLengthMultiplier / 100.0;
+			if (avoidSamePitchCollision && noteLengthMultiplier > 100) {
+				if (i < sn.size() - 1 && n.getPitch() == sn.get(i + 1).getRight().getPitch()) {
+					double difference = sn.get(i + 1).getLeft() - sn.get(i).getLeft();
+					duration = Math.min(duration, difference);
+				} else if (i < sn.size() - 2
+						&& n.getPitch() == sn.get(i + 2).getRight().getPitch()) {
+					double difference = sn.get(i + 2).getLeft() - sn.get(i).getLeft();
+					duration = Math.min(duration, difference);
+				}
+			}
+			n.setDuration(duration);
+		}
+	}
+
+	static int addAccent(int velocity, Random accentGenerator, int accent) {
+		int newVelocity = velocity + MidiGenerator.BASE_ACCENT + accentGenerator.nextInt(11) - 5 + accent / 20;
+		return OMNI.clamp(newVelocity, 0, 127);
+	}
+
+	static void applyCrescendoMultiplierMinimum(List<Note> notes, double maxDuration,
+			double crescendoStartPercentage, double maxMultiplierAdd, double minimum) {
+		double dur = 0.0;
+		double start = maxDuration * crescendoStartPercentage;
+		for (Note n : notes) {
+			if (dur > start) {
+				double multiplier = minimum
+						+ maxMultiplierAdd * ((dur - start) / (maxDuration - start));
+				if (multiplier < 0.1) {
+					n.setPitch(Note.REST);
+				} else {
+					n.setDynamic(OMNI.clampVel(n.getDynamic() * multiplier));
+				}
+				//LG.d("Applied multiplier: " + multiplier);
+			}
+			dur += n.getRhythmValue();
+		}
+	}
+
+	static void applyCrescendoMultiplier(List<Note> notes, double maxDuration,
+			double crescendoStartPercentage, double maxMultiplierAdd) {
+		applyCrescendoMultiplierMinimum(notes, maxDuration, crescendoStartPercentage,
+				maxMultiplierAdd, 1);
+	}
+
+	static void processSectionTransition(Section sec, List<Note> notes, double maxDuration,
+			double crescendoStartPercentage, double maxMultiplierAdd, double muteStartPercentage) {
+		if (sec.isTransition()) {
+			applyCrescendoMultiplier(notes, maxDuration, crescendoStartPercentage,
+					maxMultiplierAdd);
+			if (sec.getTransitionType() == 3) {
+				applyCrescendoMultiplierMinimum(notes, maxDuration, muteStartPercentage, 0.05,
+						0.05);
+			}
+		}
+	}
+
+	static void applyBadIntervalRemoval(List<Note> fullMelody) {
+	
+		int previousPitch = -1;
+		for (int i = 0; i < fullMelody.size(); i++) {
+			Note n = fullMelody.get(i);
+			int pitch = n.getPitch();
+			if (pitch < 0) {
+				continue;
+			}
+			// remove all instances of B-F and F-B (the only interval of 6 within the key)
+			if (previousPitch % 12 == 11 && Math.abs(pitch - previousPitch) == 6) {
+				n.setPitch(pitch - 1);
+			} else if (pitch % 12 == 11 && Math.abs(pitch - previousPitch) == 6) {
+				n.setPitch(pitch + 1);
+			}
+			previousPitch = n.getPitch();
+		}
+	
+	
+	}
+
+	static void replaceAvoidNotes(Map<Integer, List<Note>> fullMelodyMap,
+			List<int[]> chords, int randomSeed, int notesToAvoid) {
+		Random rand = new Random(randomSeed);
+		for (int i = 0; i < fullMelodyMap.keySet().size(); i++) {
+			Set<Integer> avoidNotes = MidiUtils.avoidNotesFromChord(chords.get(i % chords.size()),
+					notesToAvoid);
+			//LG.d(StringUtils.join(avoidNotes, ","));
+			List<Note> notes = fullMelodyMap.get(i);
+			for (int j = 0; j < notes.size(); j++) {
+				Note n = notes.get(j);
+				int oldPitch = n.getPitch();
+				if (oldPitch < 0) {
+					continue;
+				}
+				//LG.d("Note: " + n.getPitch() + ", RV: " + n.getRhythmValue());
+				boolean avoidAllLengths = true;
+				if (avoidAllLengths || (n.getRhythmValue() > MidiGenerator.Durations.EIGHTH_NOTE - MidiGenerator.DBL_ERR)) {
+					if (avoidNotes.contains(oldPitch % 12)) {
+						int normalizedPitch = oldPitch % 12;
+						int pitchIndex = MidiUtils.MAJ_SCALE.indexOf(normalizedPitch);
+						int upOrDown = rand.nextBoolean() ? 1 : -1;
+						int newPitch = oldPitch - normalizedPitch;
+						newPitch += MidiUtils.MAJ_SCALE.get((pitchIndex + upOrDown + 7) % 7);
+						if (pitchIndex == 6 && upOrDown == 1) {
+							newPitch += 12;
+						} else if (pitchIndex == 0 && upOrDown == -1) {
+							newPitch -= 12;
+						}
+						n.setPitch(newPitch);
+						/*LG.d("Avoiding note: " + j + ", in chord: " + i + ", pitch change: "
+								+ (oldPitch - newPitch));*/
+					}
+				}
+	
+			}
+		}
+	
+	}
+
+	static int pickRandomBetweenIndexesInclusive(int[] chord, int startIndex, int endIndex,
+			Random generator, double posInChord) {
+		//clamp
+		if (startIndex < 0)
+			startIndex = 0;
+		if (endIndex > chord.length - 1) {
+			endIndex = chord.length - 1;
+		}
+		if (((chord[startIndex] % 12 == 11) && (chord[endIndex] % 12 == 11)) || posInChord > 0.66) {
+			// do nothing
+			//LG.d("The forced B case, " + posInChord);
+		} else if (chord[startIndex] % 12 == 11) {
+			startIndex++;
+			//LG.d("B start avoided");
+		} else if (chord[endIndex] % 12 == 11) {
+			endIndex--;
+			//LG.d("B end avoided");
+		}
+		int index = generator.nextInt(endIndex - startIndex + 1) + startIndex;
+		return chord[index];
+	}
+
+	static int selectClosestIndexFromChord(int[] chord, int previousNotePitch,
+			boolean directionUp) {
+		if (directionUp) {
+			for (int i = 0; i < chord.length; i++) {
+				if (previousNotePitch < chord[i]) {
+					return i;
+				}
+			}
+			return chord.length - 1;
+		} else {
+			for (int i = chord.length - 1; i > 0; i--) {
+				if (previousNotePitch > chord[i]) {
+					return i;
+				}
+			}
+			return 0;
+		}
+	
+	}
+
+	static String generateSpicyChordString(Random spiceGenerator, String chordString,
+			List<String> spicyChordList) {
+		List<String> spicyChordListCopy = new ArrayList<>(spicyChordList);
+		String firstLetter = chordString.substring(0, 1);
+		List<Integer> targetScale = Arrays.asList(ScaleMode.IONIAN.noteAdjustScale);
+		int transposeByLetter = targetScale.get(MidiUtils.CHORD_FIRST_LETTERS.indexOf(firstLetter));
+		if (MidiGenerator.gc != null && MidiGenerator.gc.isSpiceForceScale()) {
+			spicyChordListCopy
+					.removeIf(e -> !MidiUtils.isSpiceValid(transposeByLetter, e, targetScale));
+		}
+	
+		//LG.d(StringUtils.join(spicyChordListCopy, ", "));
+	
+		if (spicyChordListCopy.isEmpty()) {
+			return chordString;
+		}
+		String spicyChordString = firstLetter
+				+ spicyChordListCopy.get(spiceGenerator.nextInt(spicyChordListCopy.size()));
+		if (chordString.endsWith("m") && spicyChordString.contains("maj")) {
+			spicyChordString = spicyChordString.replace("maj", "m");
+		} else if (chordString.length() == 1 && spicyChordString.contains("m")
+				&& !spicyChordString.contains("dim") && !spicyChordString.contains("maj")) {
+			spicyChordString = spicyChordString.replace("m", "maj");
+		}
+		return spicyChordString;
+	}
+
+}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
@@ -578,13 +578,16 @@ public class MidiGeneratorUtils {
 		return spicyChordString;
 	}
 
-	static void multiDelayPhrase(Phrase phr, int delayCount, double delayAmnt) {
+	static void multiDelayPhrase(Phrase phr, int delayCount, double delayAmnt,
+			double volMultiplier) {
 		if (delayCount <= 0) {
 			return;
 		}
 		List<Double> delays = DoubleStream.iterate(delayAmnt, e -> e + delayAmnt).limit(delayCount)
 				.boxed().collect(Collectors.toList());
-		multiDelayPhrase(phr, delays);
+		List<Double> volMultipliers = DoubleStream.iterate(volMultiplier, e -> e * volMultiplier)
+				.limit(delays.size()).boxed().collect(Collectors.toList());
+		multiDelayPhrase(phr, delays, volMultipliers);
 
 	}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
@@ -457,7 +457,7 @@ public class MidiGeneratorUtils {
 			} else if ((i < fullMelody.size() - 1)
 					&& (pitch - fullMelody.get(i + 1).getPitch() >= 12)) {
 				// set G as a step for too wild intervals
-				LG.i("I like ya cut, G");
+				LG.i("Reducing interval - changing note to 5th");
 				n.setPitch(pitch - (pitch % 12) + 7);
 			}
 			previousPitch = n.getPitch();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
@@ -397,6 +397,7 @@ public class MidiGeneratorUtils {
 	}
 
 	static int addAccent(int velocity, Random accentGenerator, int accent) {
+		// 80 + 15 +- 5 + 100/20 -> 95-105 vel.
 		int newVelocity = velocity + MidiGenerator.BASE_ACCENT + accentGenerator.nextInt(11) - 5
 				+ accent / 20;
 		return OMNI.clamp(newVelocity, 0, 127);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
@@ -9,15 +9,14 @@ import java.util.Random;
 import java.util.Set;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.vibehistorian.vibecomposer.MidiGenerator.Durations;
 import org.vibehistorian.vibecomposer.MidiUtils.ScaleMode;
 
 import jm.music.data.Note;
 
 public class MidiGeneratorUtils {
 
-	static List<Integer> generateMelodyOffsetDirectionsFromChordProgression(
-			List<int[]> progression, boolean roots, int randomSeed) {
+	static List<Integer> generateMelodyOffsetDirectionsFromChordProgression(List<int[]> progression,
+			boolean roots, int randomSeed) {
 		Random rand = new Random(randomSeed);
 		List<Integer> dirs = new ArrayList<>();
 		dirs.add(0);
@@ -34,7 +33,7 @@ public class MidiGeneratorUtils {
 
 	static List<Integer> randomizedChordDirections(int chords, int randomSeed) {
 		Random rand = new Random(randomSeed);
-	
+
 		List<Integer> chordDirs = new ArrayList<>(MelodyUtils.CHORD_DIRECTIONS
 				.get(rand.nextInt(MelodyUtils.CHORD_DIRECTIONS.size())));
 		while (chordDirs.size() < chords) {
@@ -100,7 +99,7 @@ public class MidiGeneratorUtils {
 		if (chordSize < 2 || !sec.isTransition()) {
 			return param;
 		}
-	
+
 		int minAffectedChord = OMNI.clamp((int) (affectedMeasure * chordSize) - 1, 1,
 				chordSize - 1);
 		//LG.d("Min affected: " + minAffectedChord);
@@ -108,13 +107,13 @@ public class MidiGeneratorUtils {
 			return param;
 		}
 		//LG.d("Old param: " + param);
-	
+
 		int chordRange = chordSize - 1 - minAffectedChord;
 		double effect = (chordRange > 0) ? ((chordNum - minAffectedChord) / ((double) chordRange))
 				: 1.0;
-	
+
 		int transitionType = sec.getTransitionType();
-	
+
 		int multiplier = reverseEffect ? -1 : 1;
 		if (transitionType == 1) {
 			param += maxEffect * effect * multiplier;
@@ -149,7 +148,8 @@ public class MidiGeneratorUtils {
 		for (int i = 0; i < chordStrings.size(); i++) {
 			chords.add(MidiUtils.mappedChord(chordStrings.get(i)));
 		}
-		return MidiGeneratorUtils.generateOffsets(chords, randomSeed, targetMode, targetNoteVariation);
+		return MidiGeneratorUtils.generateOffsets(chords, randomSeed, targetMode,
+				targetNoteVariation);
 	}
 
 	static Pair<Integer, Integer> normalizeNotePitch(int startingNote, int startingPitch) {
@@ -170,8 +170,8 @@ public class MidiGeneratorUtils {
 		List<Integer> chordOffsets = convertRootsToOffsets(getRootIndexes(chords), targetMode);
 		List<Integer> multipliedDirections = multipliedDirections(
 				MidiGenerator.gc != null && MidiGenerator.gc.isMelodyUseDirectionsFromProgression()
-						? generateMelodyOffsetDirectionsFromChordProgression(
-								chords, true, randomSeed)
+						? generateMelodyOffsetDirectionsFromChordProgression(chords, true,
+								randomSeed)
 						: randomizedChordDirections(chords.size(), randomSeed),
 				randomSeed + 1, targetNoteVariation);
 		List<Integer> offsets = new ArrayList<>();
@@ -183,7 +183,7 @@ public class MidiGeneratorUtils {
 			} else {
 				offsets.add(multipliedDirections.get(i));
 			}
-	
+
 		}
 		if (targetMode >= 1) {
 			Map<Integer, List<Integer>> choiceMap = getChordNoteChoicesFromChords(chords);
@@ -212,23 +212,23 @@ public class MidiGeneratorUtils {
 				offsets.set(offsets.size() - 1, last);
 			}
 		}
-	
+
 		//int min = offsets.stream().min((e1, e2) -> e1.compareTo(e2)).get();
 		/*if (min == -1) {
 			for (int i = 0; i < offsets.size(); i++) {
 				offsets.set(i, offsets.get(i) + 1);
 			}
 		}*/
-	
+
 		LG.d("RANDOMIZED OFFSETS");
 		return offsets;
 	}
 
-	static List<Boolean> generateMelodyDirectionsFromChordProgression(
-			List<int[]> progression, boolean roots) {
-	
+	static List<Boolean> generateMelodyDirectionsFromChordProgression(List<int[]> progression,
+			boolean roots) {
+
 		List<Boolean> ascDirectionList = new ArrayList<>();
-	
+
 		for (int i = 0; i < progression.size(); i++) {
 			if (roots) {
 				int current = progression.get(i)[0];
@@ -241,9 +241,9 @@ public class MidiGeneratorUtils {
 								- 1];
 				ascDirectionList.add(Boolean.valueOf(current <= next));
 			}
-	
+
 		}
-	
+
 		return ascDirectionList;
 	}
 
@@ -252,7 +252,7 @@ public class MidiGeneratorUtils {
 		for (int i = 0; i < chords; i++) {
 			double divider = dirGen.nextDouble() * 0.80 + 0.20;
 			map.add(divider);
-	
+
 		}
 		return map;
 	}
@@ -273,7 +273,7 @@ public class MidiGeneratorUtils {
 
 	public static int getAllowedPitchFromRange(int min, int max, double posInChord,
 			Random splitNoteGen) {
-	
+
 		boolean allowBs = posInChord > 0.66;
 		//LG.i("Min: " + min + ", max: " + max);
 		int normMin = min % 12;
@@ -281,11 +281,11 @@ public class MidiGeneratorUtils {
 		if (normMax <= normMin) {
 			normMax += 12;
 		}
-	
+
 		List<Integer> allowedPitches = new ArrayList<>(MidiUtils.MAJ_SCALE);
 		int allowedPitchSize = allowedPitches.size();
 		for (int i = 0; i < allowedPitchSize; i++) {
-	
+
 			allowedPitches.add(allowedPitches.get(i) + 12);
 		}
 		//LG.i("Size: " + allowedPitches.size());
@@ -337,7 +337,7 @@ public class MidiGeneratorUtils {
 			}
 		}
 		durations.add(dur);
-	
+
 		return durations;
 	}
 
@@ -352,15 +352,15 @@ public class MidiGeneratorUtils {
 		}
 	}
 
-	static int getStartingNote(List<int[]> stretchedChords,
-			List<Integer> blockChordNoteChoices, int chordNum, int BLOCK_TARGET_MODE) {
-	
+	static int getStartingNote(List<int[]> stretchedChords, List<Integer> blockChordNoteChoices,
+			int chordNum, int BLOCK_TARGET_MODE) {
+
 		int chordNumIndex = chordNum % stretchedChords.size();
 		int chordNoteChoiceIndex = (BLOCK_TARGET_MODE == 2
 				&& chordNum == blockChordNoteChoices.size()) ? (chordNum - 1)
 						: (chordNum % blockChordNoteChoices.size());
 		int[] chord = stretchedChords.get(chordNumIndex);
-	
+
 		int startingPitch = (BLOCK_TARGET_MODE == 0)
 				? MidiUtils.getXthChordNote(blockChordNoteChoices.get(chordNoteChoiceIndex), chord)
 				: ((BLOCK_TARGET_MODE == 1) ? chord[0] : (5 * 12));
@@ -397,7 +397,8 @@ public class MidiGeneratorUtils {
 	}
 
 	static int addAccent(int velocity, Random accentGenerator, int accent) {
-		int newVelocity = velocity + MidiGenerator.BASE_ACCENT + accentGenerator.nextInt(11) - 5 + accent / 20;
+		int newVelocity = velocity + MidiGenerator.BASE_ACCENT + accentGenerator.nextInt(11) - 5
+				+ accent / 20;
 		return OMNI.clamp(newVelocity, 0, 127);
 	}
 
@@ -439,7 +440,7 @@ public class MidiGeneratorUtils {
 	}
 
 	static void applyBadIntervalRemoval(List<Note> fullMelody) {
-	
+
 		int previousPitch = -1;
 		for (int i = 0; i < fullMelody.size(); i++) {
 			Note n = fullMelody.get(i);
@@ -452,15 +453,20 @@ public class MidiGeneratorUtils {
 				n.setPitch(pitch - 1);
 			} else if (pitch % 12 == 11 && Math.abs(pitch - previousPitch) == 6) {
 				n.setPitch(pitch + 1);
+			} else if ((i < fullMelody.size() - 1)
+					&& (pitch - fullMelody.get(i + 1).getPitch() >= 12)) {
+				// set G as a step for too wild intervals
+				LG.i("I like ya cut, G");
+				n.setPitch(pitch - (pitch % 12) + 7);
 			}
 			previousPitch = n.getPitch();
 		}
-	
-	
+
+
 	}
 
-	static void replaceAvoidNotes(Map<Integer, List<Note>> fullMelodyMap,
-			List<int[]> chords, int randomSeed, int notesToAvoid) {
+	static void replaceAvoidNotes(Map<Integer, List<Note>> fullMelodyMap, List<int[]> chords,
+			int randomSeed, int notesToAvoid) {
 		Random rand = new Random(randomSeed);
 		for (int i = 0; i < fullMelodyMap.keySet().size(); i++) {
 			Set<Integer> avoidNotes = MidiUtils.avoidNotesFromChord(chords.get(i % chords.size()),
@@ -475,7 +481,8 @@ public class MidiGeneratorUtils {
 				}
 				//LG.d("Note: " + n.getPitch() + ", RV: " + n.getRhythmValue());
 				boolean avoidAllLengths = true;
-				if (avoidAllLengths || (n.getRhythmValue() > MidiGenerator.Durations.EIGHTH_NOTE - MidiGenerator.DBL_ERR)) {
+				if (avoidAllLengths || (n.getRhythmValue() > MidiGenerator.Durations.EIGHTH_NOTE
+						- MidiGenerator.DBL_ERR)) {
 					if (avoidNotes.contains(oldPitch % 12)) {
 						int normalizedPitch = oldPitch % 12;
 						int pitchIndex = MidiUtils.MAJ_SCALE.indexOf(normalizedPitch);
@@ -492,10 +499,10 @@ public class MidiGeneratorUtils {
 								+ (oldPitch - newPitch));*/
 					}
 				}
-	
+
 			}
 		}
-	
+
 	}
 
 	static int pickRandomBetweenIndexesInclusive(int[] chord, int startIndex, int endIndex,
@@ -537,7 +544,7 @@ public class MidiGeneratorUtils {
 			}
 			return 0;
 		}
-	
+
 	}
 
 	static String generateSpicyChordString(Random spiceGenerator, String chordString,
@@ -550,9 +557,9 @@ public class MidiGeneratorUtils {
 			spicyChordListCopy
 					.removeIf(e -> !MidiUtils.isSpiceValid(transposeByLetter, e, targetScale));
 		}
-	
+
 		//LG.d(StringUtils.join(spicyChordListCopy, ", "));
-	
+
 		if (spicyChordListCopy.isEmpty()) {
 			return chordString;
 		}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
@@ -1346,23 +1346,6 @@ public class MidiUtils {
 		return returnChord;
 	}
 
-	public static String getNoteForPitch(int pitch) {
-		if (pitch < 0) {
-			return "";
-		}
-		int pitchNormalized = pitch % 12;
-		List<Integer> majorLetterPitches = MAJ_SCALE;
-		int chordLetter = majorLetterPitches.indexOf(pitchNormalized);
-		if (chordLetter < 0) {
-			chordLetter = majorLetterPitches.indexOf(pitchNormalized - 1);
-			String realLetter = CHORD_FIRST_LETTERS.get(chordLetter) + "#";
-			return realLetter + pitch / 12;
-		} else {
-			String realLetter = CHORD_FIRST_LETTERS.get(chordLetter);
-			return realLetter + pitch / 12;
-		}
-	}
-
 	public static List<String> respiceChords(String chordsString, GUIConfig gc) {
 		List<String> allowedSpiceChordsMiddle = new ArrayList<>();
 		for (int i = 2; i < SPICE_NAMES_LIST.size(); i++) {
@@ -1488,7 +1471,30 @@ public class MidiUtils {
 	}
 
 	public static String pitchToString(int pitch) {
+		if (pitch < 0) {
+			return "";
+		}
 		return MidiUtils.SEMITONE_LETTERS.get((pitch + 1200) % 12) + ((pitch / 12) - 1);
+	}
+
+	public static String pitchOrDrumToString(int pitch, int part, boolean forceGmNames) {
+		if (part < 4) {
+			return pitchToString(pitch);
+		} else {
+			if (MidiGenerator.gc.isDrumCustomMapping() && !forceGmNames) {
+				Integer drumIndex = OMNI.indexOf(pitch, InstUtils.DRUM_INST_NUMBERS_SEMI);
+				if (drumIndex < 0) {
+					return pitchToString(pitch);
+				}
+				return InstUtils.DRUM_INST_NAMES_SEMI[drumIndex];
+			} else {
+				Integer drumIndex = OMNI.indexOf(pitch, InstUtils.DRUM_INST_NUMBERS);
+				if (drumIndex < 0) {
+					return pitchToString(pitch);
+				}
+				return InstUtils.DRUM_INST_NAMES[drumIndex];
+			}
+		}
 	}
 
 	public static void scalePhrase(Phrase phr, double newLength) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
@@ -443,10 +443,16 @@ public class MidiUtils {
 
 	public static int compareNotesByDistanceFromChordPitches(Note n1, Note n2,
 			List<Integer> pitches) {
-		int dist1 = Math
-				.abs((n1.getPitch() % 12) - getClosestFromList(pitches, n1.getPitch() % 12));
-		int dist2 = Math
-				.abs((n2.getPitch() % 12) - getClosestFromList(pitches, n2.getPitch() % 12));
+		int dist1 = getSemitonalDistance(n1.getPitch(),
+				getClosestPitchFromList(pitches, n1.getPitch()));
+		int dist2 = getSemitonalDistance(n2.getPitch(),
+				getClosestPitchFromList(pitches, n2.getPitch()));
+		return Integer.compare(dist1, dist2);
+	}
+
+	public static int compareNotesByDistanceFromModeNote(Note n1, Note n2, int modeNote) {
+		int dist1 = getSemitonalDistance(n1.getPitch(), modeNote);
+		int dist2 = getSemitonalDistance(n2.getPitch(), modeNote);
 		return Integer.compare(dist1, dist2);
 	}
 
@@ -1080,6 +1086,51 @@ public class MidiUtils {
 
 			n.setPitch(pitch - originalMovement + newMovement);
 		}
+	}
+
+	public static int getClosestPitchFromList(List<Integer> list, int valToFind) {
+		if (list == null || list.isEmpty()) {
+			return Integer.MIN_VALUE;
+		}
+		valToFind = valToFind % 12;
+
+		int closest = list.get(0);
+		int closestDistance = Math.abs(valToFind - closest);
+		for (int i = 1; i < list.size(); i++) {
+			int distance = Math.abs(valToFind - list.get(i));
+			if (distance < closestDistance) {
+				closestDistance = distance;
+				closest = list.get(i);
+			}
+		}
+		// try with +12 and -12 (octave)
+		int distance = Math.abs(valToFind + 12 - list.get(list.size() - 1));
+		if (distance < closestDistance) {
+			closestDistance = distance;
+			closest = list.get(list.size() - 1);
+		}
+		distance = Math.abs(valToFind - 12 - list.get(0));
+		if (distance < closestDistance) {
+			closestDistance = distance;
+			closest = list.get(0);
+		}
+		return closest;
+	}
+
+	public static int getSemitonalDistance(int pitch1, int pitch2) {
+		pitch1 %= 12;
+		pitch2 %= 12;
+		int distance = Math.abs(pitch1 - pitch2);
+		int distanceOct = Math.abs(pitch1 + 12 - pitch2);
+		if (distanceOct > distance) {
+			distanceOct = Math.abs(pitch1 - 12 - pitch2);
+			if (distanceOct < distance) {
+				distance = distanceOct;
+			}
+		} else {
+			distance = distanceOct;
+		}
+		return distance;
 	}
 
 	public static int getClosestFromList(List<Integer> list, int valToFind) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
@@ -1533,4 +1533,8 @@ public class MidiUtils {
 		return inKey / (double) mapped.length;
 	}
 
+	public static int octavePitch(int pitch) {
+		return pitch - pitch % 12;
+	}
+
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
@@ -62,7 +62,8 @@ public class MidiUtils {
 				BLUES_SCALE = { 0, 2, 3, 4, 7, 9, 12 }, TURKISH_SCALE = { 0, 1, 3, 5, 7, 10, 11 },
 				INDIAN_SCALE = { 0, 1, 1, 4, 5, 8, 10 }, LOCRIAN_SCALE = { 0, 1, 3, 4, 6, 8, 10 },
 				HARMONIC_MAJOR_SCALE = { 0, 2, 4, 5, 7, 8, 11 },
-				WHISKEY_SCALE = { 0, 3, 5, 6, 7, 10, 11 };
+				WHISKEY_SCALE = { 0, 3, 5, 6, 7, 10, 11 },
+				DOUBLE_HARM_SCALE = { 0, 1, 4, 5, 7, 8, 11 };
 
 	}
 
@@ -93,7 +94,7 @@ public class MidiUtils {
 		LOCRIAN(Scales.LOCRIAN_SCALE, 4), BLUES(Scales.BLUES_SCALE, -1),
 		HARM_MINOR(Scales.HARMONIC_MINOR_SCALE, 5), TURKISH(Scales.TURKISH_SCALE, -1),
 		INDIAN(Scales.INDIAN_SCALE, 2), HARM_MAJOR(Scales.HARMONIC_MAJOR_SCALE, 5),
-		WHISKEY(Scales.WHISKEY_SCALE, 1);
+		WHISKEY(Scales.WHISKEY_SCALE, 1), DOUBLE_HARM(Scales.DOUBLE_HARM_SCALE, 1);
 
 		public Integer[] noteAdjustScale;
 		public Integer modeTargetNote;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
@@ -1510,8 +1510,8 @@ public class MidiUtils {
 		return Math.abs(first - second) < MidiGenerator.DBL_ERR;
 	}
 
-	public static boolean isMultiple(double first, double second) {
-		double result = first / second;
+	public static boolean isMultiple(double bigger, double smaller) {
+		double result = bigger / smaller;
 		double rounded = Math.round(result);
 		if (roughlyEqual(result, rounded)) {
 			return true;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/OMNI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/OMNI.java
@@ -148,4 +148,16 @@ public class OMNI {
 		return (T) list.stream().min((e1, e2) -> Double.compare(e1.doubleValue(), e2.doubleValue()))
 				.get();
 	}
+
+	public static <T> int indexOf(T elem, T[] array) {
+		if (array == null) {
+			return -1;
+		}
+		for (int i = 0; i < array.length; i++) {
+			if (array[i].equals(elem)) {
+				return i;
+			}
+		}
+		return -1;
+	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ArpPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ArpPanel.java
@@ -75,6 +75,7 @@ public class ArpPanel extends InstPanel {
 
 
 		this.add(exceptionChance);
+		this.add(swingPercent);
 		this.add(delay);
 
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ArpPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ArpPanel.java
@@ -76,7 +76,7 @@ public class ArpPanel extends InstPanel {
 
 		this.add(exceptionChance);
 		this.add(swingPercent);
-		this.add(delay);
+		addOffsetAndDelayControls();
 
 
 		this.add(patternSeedLabel);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/BassPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/BassPanel.java
@@ -38,7 +38,7 @@ public class BassPanel extends InstPanel {
 		instrument.initInstPool(instPool);
 		setInstrument(74);
 		initDefaults(l);
-		volSlider.setDefaultValue(69);
+		volSlider.setDefaultValue(50);
 		this.add(volSlider);
 		this.add(panSlider);
 		this.add(new JLabel("#"));

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ChordPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ChordPanel.java
@@ -5,8 +5,6 @@ import java.awt.Insets;
 import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -80,8 +78,7 @@ public class ChordPanel extends InstPanel {
 		this.add(strumType);
 		this.add(strumPauseChance);
 
-		strum.getKnob().setTickThresholds(Arrays.stream(VibeComposerGUI.MILISECOND_ARRAY_STRUM)
-				.mapToObj(e -> Integer.valueOf(e)).collect(Collectors.toList()));
+		strum.getKnob().setTickThresholds(VibeComposerGUI.MILISECOND_LIST_STRUM);
 		strum.getKnob().setTickSpacing(50);
 
 		this.add(stretchPanel);
@@ -93,7 +90,7 @@ public class ChordPanel extends InstPanel {
 		this.add(transitionChance);
 		this.add(transitionSplit);
 		this.add(swingPercent);
-		this.add(delay);
+		addOffsetAndDelayControls();
 
 
 		this.add(patternSeedLabel);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ChordPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ChordPanel.java
@@ -92,6 +92,7 @@ public class ChordPanel extends InstPanel {
 
 		this.add(transitionChance);
 		this.add(transitionSplit);
+		this.add(swingPercent);
 		this.add(delay);
 
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ChordletPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ChordletPanel.java
@@ -360,13 +360,13 @@ public class ChordletPanel extends JPanel {
 		update();
 	}
 
-	public void conformToMelodyPattern(List<Integer> chordNoteChoices) {
+	public void alignWithMelodyTargetNotes(List<Integer> melodyTargetNotes) {
 		// goal1: align top notes of chords with melody
 		// goal2: also copy up/down flow of melody
 
 		for (int i = 0; i < chordCount(); i++) {
 			int[] mapped = MidiUtils.mappedChord(chordlets.get(i).getChordText());
-			int melodyChoice = chordNoteChoices.get(i % chordNoteChoices.size());
+			int melodyChoice = melodyTargetNotes.get(i % melodyTargetNotes.size());
 			int melodyNote = MidiUtils.MAJ_SCALE.get((melodyChoice + 70) % 7) % 12;
 
 			if (mapped[mapped.length - 1] % 12 == melodyNote) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ChordletPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ChordletPanel.java
@@ -365,7 +365,7 @@ public class ChordletPanel extends JPanel {
 		// goal2: also copy up/down flow of melody
 
 		for (int i = 0; i < chordCount(); i++) {
-			int[] mapped = MidiUtils.mappedChord(chordlets.get(i).getChordText());
+			int[] mapped = MidiUtils.mappedChord(chordlets.get(i).getSpicedText());
 			int melodyChoice = melodyTargetNotes.get(i % melodyTargetNotes.size());
 			int melodyNote = MidiUtils.MAJ_SCALE.get((melodyChoice + 70) % 7) % 12;
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ChordletPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ChordletPanel.java
@@ -367,60 +367,42 @@ public class ChordletPanel extends JPanel {
 		Integer prevNote = null;
 		for (int i = 0; i < chordCount(); i++) {
 			int[] mapped = MidiUtils.mappedChord(chordlets.get(i).getSpicedText());
+			List<Integer> pitches = MidiUtils.chordToPitches(mapped);
 			int melodyChoice = melodyTargetNotes.get(i % melodyTargetNotes.size());
 			int melodyNote = MidiUtils.MAJ_SCALE.get((melodyChoice + 70) % 7) % 12;
+			// round note to closest from chord
+			int noteInChordIndex = pitches
+					.indexOf(MidiUtils.getClosestFromList(pitches, melodyNote));
 
-			if (mapped[mapped.length - 1] % 12 == melodyNote) {
-				int newNote = MidiUtils.getXthChordNote(mapped.length - 1, mapped);
-				int inversion = 0;
-				if (i > 0) {
-					if (newNote > prevNote && melodyTargetNotes
-							.get((i - 1) % melodyTargetNotes.size()) > melodyChoice) {
-						inversion -= mapped.length;
-					} else if (newNote < prevNote && melodyTargetNotes
-							.get((i - 1) % melodyTargetNotes.size()) < melodyChoice) {
-						inversion += mapped.length;
-					} else if (newNote - 12 >= prevNote) {
-						inversion -= mapped.length;
-					} else if (newNote + 12 <= prevNote) {
-						inversion += mapped.length;
-					}
-				}
-				prevNote = MidiUtils.getXthChordNote(mapped.length - 1 + inversion, mapped);
-				chordlets.get(i).updateInversion(inversion);
-				continue;
+			int inversion = 0;
+			if (noteInChordIndex < mapped.length - 1) {
+				inversion = (melodyChoice >= 0) ? (noteInChordIndex + 1)
+						: (-1 * (mapped.length - noteInChordIndex - 1));
 			}
 
-			for (int j = 0; j < mapped.length - 1; j++) {
-				if ((mapped[j] % 12) == melodyNote) {
-					int inversion = (melodyChoice >= 0) ? (j + 1) : (-1 * (mapped.length - j - 1));
-					int newNote = MidiUtils.getXthChordNote(mapped.length - 1 + inversion, mapped);
-					if (i > 0) {
-						if (newNote > prevNote && melodyTargetNotes
-								.get((i - 1) % melodyTargetNotes.size()) > melodyChoice) {
-							inversion -= mapped.length;
-						} else if (newNote < prevNote && melodyTargetNotes
-								.get((i - 1) % melodyTargetNotes.size()) < melodyChoice) {
-							inversion += mapped.length;
-						} else if (newNote - 12 >= prevNote) {
-							inversion -= mapped.length;
-						} else if (newNote + 12 <= prevNote) {
-							inversion += mapped.length;
-						}
-					} else {
-						if (inversion > 0 && Math.abs(inversion - mapped.length) < inversion) {
-							inversion -= mapped.length;
-						} else if (inversion < 0
-								&& Math.abs(inversion + mapped.length) < Math.abs(inversion)) {
-							inversion += mapped.length;
-						}
-					}
-					prevNote = MidiUtils.getXthChordNote(mapped.length - 1 + inversion, mapped);
-					chordlets.get(i).updateInversion(inversion);
-					break;
+			int newNote = MidiUtils.getXthChordNote(mapped.length - 1 + inversion, mapped);
+			if (i > 0) {
+				if (newNote > prevNote && melodyTargetNotes
+						.get((i - 1) % melodyTargetNotes.size()) > melodyChoice) {
+					inversion -= mapped.length;
+				} else if (newNote < prevNote && melodyTargetNotes
+						.get((i - 1) % melodyTargetNotes.size()) < melodyChoice) {
+					inversion += mapped.length;
+				} else if (newNote - 12 >= prevNote) {
+					inversion -= mapped.length;
+				} else if (newNote + 12 <= prevNote) {
+					inversion += mapped.length;
 				}
-
+			} else if (inversion != 0) {
+				if (inversion > 0 && Math.abs(inversion - mapped.length) < inversion) {
+					inversion -= mapped.length;
+				} else if (inversion < 0
+						&& Math.abs(inversion + mapped.length) < Math.abs(inversion)) {
+					inversion += mapped.length;
+				}
 			}
+			prevNote = MidiUtils.getXthChordNote(mapped.length - 1 + inversion, mapped);
+			chordlets.get(i).updateInversion(inversion);
 		}
 	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ChordletPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ChordletPanel.java
@@ -359,4 +359,29 @@ public class ChordletPanel extends JPanel {
 		}
 		update();
 	}
+
+	public void conformToMelodyPattern(List<Integer> chordNoteChoices) {
+		// goal1: align top notes of chords with melody
+		// goal2: also copy up/down flow of melody
+
+		for (int i = 0; i < chordCount(); i++) {
+			int[] mapped = MidiUtils.mappedChord(chordlets.get(i).getChordText());
+			int melodyChoice = chordNoteChoices.get(i % chordNoteChoices.size());
+			int melodyNote = MidiUtils.MAJ_SCALE.get((melodyChoice + 70) % 7) % 12;
+
+			if (mapped[mapped.length - 1] % 12 == melodyNote) {
+				chordlets.get(i).updateInversion(0);
+				continue;
+			}
+
+			for (int j = 0; j < mapped.length - 1; j++) {
+				if ((mapped[j] % 12) == melodyNote) {
+					int inversion = (melodyChoice >= 0) ? (j + 1) : (-1 * (mapped.length - j + 1));
+					chordlets.get(i).updateInversion(inversion);
+				}
+
+			}
+		}
+
+	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/DrumPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/DrumPanel.java
@@ -96,7 +96,7 @@ public class DrumPanel extends InstPanel {
 
 		this.add(new JLabel("Midi ch. 10"));
 
-		getInstrumentBox().setToolTipText("test");
+		getInstrumentBox().box().setToolTipText("test");
 		//toggleableComponents.add(useMelodyNotePattern);
 		toggleableComponents.remove(patternShift);
 		initDefaultsPost();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/DrumPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/DrumPanel.java
@@ -33,6 +33,7 @@ public class DrumPanel extends InstPanel {
 
 		instrument.initInstPool(InstUtils.POOL.DRUM);
 		instrument.setInstrument(36);
+		instrument.setScrollEnabled(false);
 		ScrollComboBox.addAll(new Integer[] { 10 }, midiChannel);
 
 		initDefaults(l);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/DrumPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/DrumPanel.java
@@ -89,7 +89,7 @@ public class DrumPanel extends InstPanel {
 		this.add(minMaxVelSlider);
 
 
-		this.add(delay);
+		addOffsetAndDelayControls();
 
 
 		this.add(patternSeedLabel);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
@@ -50,6 +50,7 @@ import javax.swing.border.BevelBorder;
 import org.apache.commons.lang3.tuple.Pair;
 import org.vibehistorian.vibecomposer.InstComboBox;
 import org.vibehistorian.vibecomposer.InstUtils;
+import org.vibehistorian.vibecomposer.LG;
 import org.vibehistorian.vibecomposer.MidiUtils;
 import org.vibehistorian.vibecomposer.OMNI;
 import org.vibehistorian.vibecomposer.Section;
@@ -934,6 +935,7 @@ public abstract class InstPanel extends JPanel {
 	public <T extends JComponent> List<T> getAllComponentsLike(JComponent c, Class<T> clazz) {
 		int indexInPanel = findIndexOfComponent(c, clazz);
 		if (indexInPanel < 0) {
+			LG.i("Found no component for global setting!");
 			return new ArrayList<>();
 		}
 		List<T> components = VibeComposerGUI.getAffectedPanels(getPartNum()).stream()

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
@@ -92,7 +92,10 @@ public abstract class InstPanel extends JPanel {
 	protected KnobPanel patternRepeat = new KnobPanel("Repeat#", 1, 1, 4);
 
 	protected KnobPanel transpose = new KnobPanel("Transpose", 0, -36, 36, 12);
-	protected KnobPanel delay = new KnobPanel("Delay", 0, -1000, 1000);
+	protected KnobPanel delay = new KnobPanel("Offset", 0, -1000, 1000);
+	protected KnobPanel feedbackCount = new KnobPanel("Delays", 0, 0, 5);
+	protected KnobPanel feedbackDuration = new KnobPanel("FB Dur.", 500, -2000, 2000);
+	protected KnobPanel feedbackVol = new KnobPanel("FB Vol.", 80, 10, 150);
 
 
 	protected RangeSlider minMaxVelSlider = new RangeSlider(0, 127);
@@ -252,9 +255,15 @@ public abstract class InstPanel extends JPanel {
 		chordSpan.getKnob().setTickSpacing(50);
 		chordSpan.getKnob().setTickThresholds(Arrays.asList(new Integer[] { 1, 2, 4 }));
 
+		feedbackDuration.getKnob().setTickThresholds(VibeComposerGUI.MILISECOND_LIST_FEEDBACK);
+		feedbackDuration.getKnob().setTickSpacing(50);
+
 		//toggleableComponents.add(stretchPanel);
 		toggleableComponents.add(exceptionChance);
 		toggleableComponents.add(delay);
+		toggleableComponents.add(feedbackDuration);
+		toggleableComponents.add(feedbackCount);
+		toggleableComponents.add(feedbackVol);
 		toggleableComponents.add(minMaxVelSlider);
 		//toggleableComponents.add(noteLengthMultiplier);
 		//toggleableComponents.add(patternShift);
@@ -276,6 +285,13 @@ public abstract class InstPanel extends JPanel {
 		this.add(customMidiToggle);
 	}
 
+	public void addOffsetAndDelayControls() {
+		this.add(delay);
+		this.add(feedbackCount);
+		this.add(feedbackDuration);
+		this.add(feedbackVol);
+	}
+
 	public void addDefaultPanelButtons() {
 		this.add(removeButton);
 		this.add(copyButton);
@@ -292,6 +308,9 @@ public abstract class InstPanel extends JPanel {
 		patternShift.addBackgroundWithBorder(OMNI.alphen(Color.red.darker().darker(), 50));
 		transpose.addBackgroundWithBorder(OMNI.alphen(Color.white, 50));
 		delay.addBackgroundWithBorder(OMNI.alphen(Color.black, 30));
+		feedbackDuration.addBackgroundWithBorder(OMNI.alphen(Color.gray, 50));
+		feedbackCount.addBackgroundWithBorder(OMNI.alphen(Color.gray, 40));
+		feedbackVol.addBackgroundWithBorder(OMNI.alphen(Color.gray, 30));
 		chordNotesStretch.addBackgroundWithBorder(OMNI.alphen(Color.PINK, 30));
 		stretchPanel.addBackground(OMNI.alphen(Color.PINK, 30));
 		chordSpanFillPanel.addBackground(OMNI.alphen(Color.green.brighter(), 40));
@@ -309,6 +328,9 @@ public abstract class InstPanel extends JPanel {
 		exceptionChance.setShowTextInKnob(b);
 		patternRepeat.setShowTextInKnob(b);
 		delay.setShowTextInKnob(b);
+		feedbackDuration.setShowTextInKnob(b);
+		feedbackCount.setShowTextInKnob(b);
+		feedbackVol.setShowTextInKnob(b);
 		swingPercent.setShowTextInKnob(b);
 		patternShift.setShowTextInKnob(b);
 		chordNotesStretch.setShowTextInKnob(b);
@@ -340,6 +362,9 @@ public abstract class InstPanel extends JPanel {
 
 		setTranspose(part.getTranspose());
 		setDelay(part.getDelay());
+		setFeedbackDuration(part.getFeedbackDuration());
+		setFeedbackCount(part.getFeedbackCount());
+		setFeedbackVol(part.getFeedbackVol());
 
 		setVelocityMin(part.getVelocityMin());
 		setVelocityMax(part.getVelocityMax());
@@ -756,6 +781,30 @@ public abstract class InstPanel extends JPanel {
 
 	public void setCustomMidiToggle(boolean val) {
 		this.customMidiToggle.setSelected(val);
+	}
+
+	public int getFeedbackCount() {
+		return feedbackCount.getInt();
+	}
+
+	public void setFeedbackCount(int val) {
+		this.feedbackCount.setInt(val);
+	}
+
+	public int getFeedbackDuration() {
+		return feedbackDuration.getInt();
+	}
+
+	public void setFeedbackDuration(int val) {
+		this.feedbackDuration.setInt(val);
+	}
+
+	public int getFeedbackVol() {
+		return feedbackVol.getInt();
+	}
+
+	public void setFeedbackVol(int val) {
+		this.feedbackVol.setInt(val);
 	}
 
 	public String panelInfo() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
@@ -89,7 +89,6 @@ public abstract class InstPanel extends JPanel {
 
 	protected KnobPanel pauseChance = new KnobPanel("Pause%", 0);
 	protected KnobPanel exceptionChance = new KnobPanel("Split%", 0);
-	protected CheckButton repeatableNotes = new CheckButton("Note<br>Repeat", true);
 	protected KnobPanel patternRepeat = new KnobPanel("Repeat#", 1, 1, 4);
 
 	protected KnobPanel transpose = new KnobPanel("Transpose", 0, -36, 36, 12);
@@ -337,7 +336,6 @@ public abstract class InstPanel extends JPanel {
 		setPauseChance(part.getPauseChance());
 		setExceptionChance(part.getExceptionChance());
 
-		setRepeatableNotes(part.isRepeatableNotes());
 		setPatternRepeat(part.getPatternRepeat());
 
 		setTranspose(part.getTranspose());
@@ -466,14 +464,6 @@ public abstract class InstPanel extends JPanel {
 	public void setMuteInst(boolean val) {
 		this.muteInst.setSelected(val);
 		muteInst.repaint();
-	}
-
-	public boolean getRepeatableNotes() {
-		return repeatableNotes.isSelected();
-	}
-
-	public void setRepeatableNotes(boolean val) {
-		this.repeatableNotes.setSelected(val);
 	}
 
 	public int getPatternRepeat() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/KnobPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/KnobPanel.java
@@ -66,6 +66,10 @@ public class KnobPanel extends TransparentablePanel {
 		return knob.updateAndGetValue();
 	}
 
+	public int getValueRaw() {
+		return knob.getValueRaw();
+	}
+
 	public void setInt(int val) {
 		knob.setValue(val);
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.vibehistorian.vibecomposer.InstUtils.POOL;
 import org.vibehistorian.vibecomposer.MelodyUtils;
 import org.vibehistorian.vibecomposer.MidiGenerator;
+import org.vibehistorian.vibecomposer.MidiGeneratorUtils;
 import org.vibehistorian.vibecomposer.MidiUtils;
 import org.vibehistorian.vibecomposer.OMNI;
 import org.vibehistorian.vibecomposer.VibeComposerGUI;
@@ -88,13 +89,13 @@ public class MelodyPanel extends InstPanel {
 		noteTargets.setMargin(new Insets(0, 0, 0, 0));
 		noteTargets.setTextGenerator(e -> {
 			return StringUtils.join(
-					MidiGenerator.generateOffsets(MidiGenerator.chordInts, new Random().nextInt(),
+					MidiGeneratorUtils.generateOffsets(MidiGenerator.chordInts, new Random().nextInt(),
 							VibeComposerGUI.melodyBlockTargetMode.getSelectedIndex(),
 							VibeComposerGUI.melodyTargetNoteVariation.getInt(), null),
 					",");
 		});
 		noteTargets.setRandGenerator(e -> {
-			return MidiGenerator.generateOffsets(MidiGenerator.chordInts, new Random().nextInt(),
+			return MidiGeneratorUtils.generateOffsets(MidiGenerator.chordInts, new Random().nextInt(),
 					VibeComposerGUI.melodyBlockTargetMode.getSelectedIndex(),
 					VibeComposerGUI.melodyTargetNoteVariation.getInt(), null);
 		});

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
@@ -32,7 +32,7 @@ public class MelodyPanel extends InstPanel {
 	private JCheckBox fillPauses = new CustomCheckBox("<html>Fill<br>Pauses</html>", false);
 	private RandomIntegerListButton noteTargets = new RandomIntegerListButton("0,2,2,4", this);
 	private RandomIntegerListButton patternStructure = new RandomIntegerListButton("1,2,1,3", this);
-	private KnobPanel maxBlockChange = new KnobPanel("Max Block<br>Change +-", 5, 0, 7);
+	private KnobPanel maxBlockChange = new KnobPanel("Max Block<br>Change +-", 7, 0, 7);
 	private KnobPanel blockJump = new KnobPanel("Block<br>Jump", 1, 0, 4);
 	private KnobPanel maxNoteExceptions = new KnobPanel("Max Note<br>Exc. #", 0, 0, 4);
 	private KnobPanel alternatingRhythmChance = new KnobPanel("Alt.<br>Pattern", 33);
@@ -48,7 +48,7 @@ public class MelodyPanel extends InstPanel {
 		midiChannel.setVal(1);
 		instPool = POOL.MELODY;
 		instrument.initInstPool(instPool);
-		setInstrument(8);
+		setInstrument(73);
 		initDefaults(l);
 		volSlider.setDefaultValue(69);
 		setVelocityMin(80);
@@ -88,14 +88,14 @@ public class MelodyPanel extends InstPanel {
 		this.add(new JLabel("<html>Note<br>Targets</html>"));
 		noteTargets.setMargin(new Insets(0, 0, 0, 0));
 		noteTargets.setTextGenerator(e -> {
-			return StringUtils.join(
-					MidiGeneratorUtils.generateOffsets(MidiGenerator.chordInts, new Random().nextInt(),
-							VibeComposerGUI.melodyBlockTargetMode.getSelectedIndex(),
-							VibeComposerGUI.melodyTargetNoteVariation.getInt(), null),
-					",");
+			return StringUtils.join(MidiGeneratorUtils.generateOffsets(MidiGenerator.chordInts,
+					new Random().nextInt(),
+					VibeComposerGUI.melodyBlockTargetMode.getSelectedIndex(),
+					VibeComposerGUI.melodyTargetNoteVariation.getInt(), null), ",");
 		});
 		noteTargets.setRandGenerator(e -> {
-			return MidiGeneratorUtils.generateOffsets(MidiGenerator.chordInts, new Random().nextInt(),
+			return MidiGeneratorUtils.generateOffsets(MidiGenerator.chordInts,
+					new Random().nextInt(),
 					VibeComposerGUI.melodyBlockTargetMode.getSelectedIndex(),
 					VibeComposerGUI.melodyTargetNoteVariation.getInt(), null);
 		});

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
@@ -145,7 +145,7 @@ public class MelodyPanel extends InstPanel {
 		this.add(doubledRhythmChance);
 		this.add(splitChance);
 		this.add(leadChordsChance);
-		this.add(delay);
+		addOffsetAndDelayControls();
 
 		this.add(patternSeedLabel);
 		this.add(patternSeed);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
@@ -259,14 +259,12 @@ public class VisualPatternPanel extends JPanel {
 			@Override
 			public void mousePressed(MouseEvent evt) {
 				if (SwingUtilities.isMiddleMouseButton(evt) && evt.isShiftDown()
-						&& !evt.isControlDown() && patternType.isEnabled()) {
-					patternType.setSelectedItem(RhythmPattern.CUSTOM);
-					shiftPanel.setInt(0);
-					Random rand = new Random();
-					for (int i = 0; i < MAX_HITS; i++) {
-						truePattern.set(i, rand.nextInt(2));
+						&& patternType.isEnabled()) {
+					if (evt.isControlDown()) {
+						randomizePatternGlobal();
+					} else {
+						randomizePattern();
 					}
-					reapplyShift();
 					if (VibeComposerGUI.canRegenerateOnChange()) {
 						VibeComposerGUI.vibeComposerGUI.composeMidi(true);
 					}
@@ -401,6 +399,33 @@ public class VisualPatternPanel extends JPanel {
 					}
 
 				});
+	}
+
+	protected void randomizePatternGlobal() {
+		InstPanel instParent = parentPanel;
+		if (instParent == null) {
+			randomizePattern();
+			repaint();
+			return;
+		}
+		List<InstPanel> allPanels = VibeComposerGUI.getAffectedPanels(instParent.getPartNum());
+		allPanels.forEach(e -> {
+			e.getComboPanel().randomizePattern();
+			e.getComboPanel().repaint();
+		});
+	}
+
+	protected void randomizePattern() {
+		//LG.i("Randomize pattern.");
+		if (patternType.isEnabled()) {
+			patternType.setSelectedItem(RhythmPattern.CUSTOM);
+			shiftPanel.setInt(0);
+			Random rand = new Random();
+			for (int i = 0; i < MAX_HITS; i++) {
+				truePattern.set(i, rand.nextInt(2));
+			}
+			reapplyShift();
+		}
 	}
 
 	public void linkDoubler(JButton doubler) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
@@ -183,17 +183,6 @@ public class VisualPatternPanel extends JPanel {
 					int mouseButt = e.getButton();
 					if (mouseButt == 1) {
 						mouseButton = -1;
-						if (isEnabled() && VibeComposerGUI.canRegenerateOnChange()) {
-							Timer tmr = new Timer(100, new ActionListener() {
-
-								@Override
-								public void actionPerformed(ActionEvent e) {
-									VibeComposerGUI.vibeComposerGUI.composeMidi(true);
-								}
-							});
-							tmr.setRepeats(false);
-							tmr.start();
-						}
 					} else if (mouseButt > 1) {
 						mouseButton = mouseButt;
 						boolean change = false;
@@ -218,9 +207,17 @@ public class VisualPatternPanel extends JPanel {
 				public void mouseReleased(MouseEvent e) {
 					mouseButton = -1;
 
-					if (e.getButton() > 1 && isEnabled()
+					if (e.getButton() >= 1 && isEnabled()
 							&& VibeComposerGUI.canRegenerateOnChange()) {
-						VibeComposerGUI.vibeComposerGUI.composeMidi(true);
+						Timer tmr = new Timer(100, new ActionListener() {
+
+							@Override
+							public void actionPerformed(ActionEvent e) {
+								VibeComposerGUI.vibeComposerGUI.composeMidi(true);
+							}
+						});
+						tmr.setRepeats(false);
+						tmr.start();
 					}
 
 					/*for (DrumPanel dp : VibeComposerGUI.drumPanels) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Parts/InstPart.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Parts/InstPart.java
@@ -50,6 +50,9 @@ public abstract class InstPart implements Cloneable {
 
 	protected int delay = 0;
 	protected int transpose = 0;
+	protected int feedbackCount = 0;
+	protected int feedbackDuration = 500;
+	protected int feedbackVol = 80;
 
 	protected int velocityMin = 69;
 	protected int velocityMax = 90;
@@ -96,6 +99,9 @@ public abstract class InstPart implements Cloneable {
 
 		setTranspose(panel.getTranspose());
 		setDelay(panel.getDelay());
+		setFeedbackDuration(panel.getFeedbackDuration());
+		setFeedbackCount(panel.getFeedbackCount());
+		setFeedbackVol(panel.getFeedbackVol());
 
 		setVelocityMin(panel.getVelocityMin());
 		setVelocityMax(panel.getVelocityMax());
@@ -409,5 +415,29 @@ public abstract class InstPart implements Cloneable {
 
 	public String partInfo() {
 		return "Part: " + getPartNum() + ", order: " + getOrder();
+	}
+
+	public int getFeedbackCount() {
+		return feedbackCount;
+	}
+
+	public void setFeedbackCount(int feedbackCount) {
+		this.feedbackCount = feedbackCount;
+	}
+
+	public int getFeedbackDuration() {
+		return feedbackDuration;
+	}
+
+	public void setFeedbackDuration(int feedbackDuration) {
+		this.feedbackDuration = feedbackDuration;
+	}
+
+	public int getFeedbackVol() {
+		return feedbackVol;
+	}
+
+	public void setFeedbackVol(int feedbackVol) {
+		this.feedbackVol = feedbackVol;
 	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Parts/InstPart.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Parts/InstPart.java
@@ -46,7 +46,6 @@ public abstract class InstPart implements Cloneable {
 
 	protected int pauseChance = 0;
 	protected int exceptionChance = 5;
-	protected boolean repeatableNotes = true;
 	protected int patternRepeat = 1;
 
 	protected int delay = 0;
@@ -93,7 +92,6 @@ public abstract class InstPart implements Cloneable {
 
 		setPauseChance(panel.getPauseChance());
 		setExceptionChance(panel.getExceptionChance());
-		setRepeatableNotes(panel.getRepeatableNotes());
 		setPatternRepeat(panel.getPatternRepeat());
 
 		setTranspose(panel.getTranspose());
@@ -178,14 +176,6 @@ public abstract class InstPart implements Cloneable {
 
 	public void setExceptionChance(int exceptionChance) {
 		this.exceptionChance = exceptionChance;
-	}
-
-	public boolean isRepeatableNotes() {
-		return repeatableNotes;
-	}
-
-	public void setRepeatableNotes(boolean repeatableNotes) {
-		this.repeatableNotes = repeatableNotes;
 	}
 
 	public int getPatternRepeat() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ArrangementGlobalVariationPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ArrangementGlobalVariationPopup.java
@@ -36,24 +36,21 @@ public class ArrangementGlobalVariationPopup extends CloseablePopup {
 
 		//addPartInclusionButtons(arr);
 
+		arr.verifyGlobalVariations();
 
 		for (int i = 0; i < 6; i++) {
 			JTable table = new JTable();
 			table.setAlignmentX(Component.LEFT_ALIGNMENT);
-			if (arr.getGlobalVariationMap() == null) {
-				arr.initGlobalVariationMap();
-			}
-			if (arr.getGlobalVariationMap().get(i) == null) {
-				arr.initGlobalVariationMap();
-			}
 			String[] colNames = null;
 			if (i < 5) {
+
 				colNames = new String[Section.variationDescriptions[i].length - 1];
 				colNames[0] = "ALL";
 				for (int j = 1; j < colNames.length; j++) {
 					colNames[j] = Section.variationDescriptions[i][j + 1];
 				}
 			} else {
+
 				colNames = new String[Section.sectionVariationNames.length + 1];
 				colNames[0] = "ALL";
 				for (int j = 1; j < colNames.length; j++) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
@@ -274,9 +274,7 @@ public class MidiEditPopup extends CloseablePopup {
 		applyToMainBtn = new CheckButton("Apply to Global",
 				VibeComposerGUI.getInstList(part).get(partOrder).getCustomMidiToggle());
 		applyToMainBtn.setFunc(e -> {
-			if (applyToMainBtn.isSelected()) {
-				mvea.getValues().setCustom(false);
-			}
+			mvea.getValues().setCustom(!applyToMainBtn.isSelected());
 			apply();
 		});
 		buttonPanel2.add(applyToMainBtn);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
@@ -99,6 +99,7 @@ public class MidiEditPopup extends CloseablePopup {
 	public ScrollComboBox<String> editHistoryBox = new ScrollComboBox<>(false);
 	public boolean applyOnClose = true;
 	public JList<File> generatedMidi;
+	public CheckButton displayDrumHelper = new CheckButton("Drum Ghosts", false);
 
 	public MidiEditPopup(Section section, int secPartNum, int secPartOrder) {
 		super("Edit MIDI Phrase (Graphical)", 14);
@@ -323,7 +324,11 @@ public class MidiEditPopup extends CloseablePopup {
 		regenerateInPlaceOnChange.setFunc(e -> {
 			regenerateInPlaceChoice = regenerateInPlaceOnChange.isSelected();
 		});
+		displayDrumHelper.setFunc(e -> {
+			repaintMvea();
+		});
 		textPanel.add(regenerateInPlaceOnChange);
+		textPanel.add(displayDrumHelper);
 		textPanel.add(new JLabel("  Highlight Mode:"));
 		textPanel.add(highlightMode);
 		textPanel.add(new JLabel("  Snap To Time:"));

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
@@ -205,7 +205,8 @@ public class MidiEditPopup extends CloseablePopup {
 							int closestNormalized = MidiUtils
 									.getClosestFromList(MidiUtils.MAJ_SCALE, pitch % 12);
 
-							mvea.getValues().get(i).setPitch(12 * (pitch / 12) + closestNormalized);
+							mvea.getValues().get(i)
+									.setPitch(MidiUtils.octavePitch(pitch) + closestNormalized);
 						} else {
 							mvea.getValues().get(i).setPitch(pitch);
 						}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
@@ -103,9 +103,8 @@ public class MidiEditPopup extends CloseablePopup {
 
 	public MidiEditPopup(Section section, int secPartNum, int secPartOrder) {
 		super("Edit MIDI Phrase (Graphical)", 14);
+		setupIdentifiers(secPartNum, secPartOrder);
 		sec = section;
-		part = secPartNum;
-		partOrder = secPartOrder;
 		applyOnClose = true;
 		LG.i("Midi Edit Popup, Part: " + secPartNum + ", Order: " + secPartOrder);
 		PhraseNotes values = sec.getPartPhraseNotes().get(part).get(partOrder);
@@ -392,6 +391,13 @@ public class MidiEditPopup extends CloseablePopup {
 		frame.add(allPanels);
 		frame.pack();
 		frame.setVisible(true);
+	}
+
+	public void setupIdentifiers(int secPartNum, int secPartOrder) {
+		part = secPartNum;
+		partOrder = secPartOrder;
+		frame.setTitle("Edit MIDI Phrase (Graphical) | Part: " + VibeComposerGUI.instNames[part]
+				+ ", Order: " + VibeComposerGUI.getInstList(part).get(partOrder).getPanelOrder());
 	}
 
 	private File buildMidiFileFromNotes() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
@@ -295,7 +295,7 @@ public class MidiEditPopup extends CloseablePopup {
 
 		JPanel textPanel = new JPanel();
 		textPanel.setLayout(new BoxLayout(textPanel, BoxLayout.X_AXIS));
-		text = new JTextField(values.toStringPitches());
+		text = new JTextField(values.toStringPitches(), 40);
 		textPanel.add(text);
 		textPanel.add(VibeComposerGUI.makeButton("Apply", e -> {
 			if (StringUtils.isNotEmpty(text.getText())) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/VariationPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/VariationPopup.java
@@ -313,7 +313,8 @@ public class VariationPopup {
 		instVolumesPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 		for (int i = 0; i < 5; i++) {
 			int val = sec.getVol(i);
-			KnobPanel panel = new DetachedKnobPanel(VibeComposerGUI.instNames[i], val, 20, 150);
+			KnobPanel panel = new DetachedKnobPanel(VibeComposerGUI.instNames[i], 100, 20, 150);
+			panel.setInt(val);
 			panel.setShowTextInKnob(VibeComposerGUI.isShowingTextInKnobs);
 			panel.addBackgroundWithBorder(OMNI.alphen(VibeComposerGUI.instColors[i], 50));
 			knobs.add(panel);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/VariationPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/VariationPopup.java
@@ -445,6 +445,9 @@ public class VariationPopup {
 				@Override
 				public void itemStateChanged(ItemEvent e) {
 					sec.setSectionVariation(index, sectionVar.isSelected() ? 1 : 0);
+					if (index == 1) {
+						sec.setDisplayAlternateChords(sectionVar.isSelected());
+					}
 					VibeComposerGUI.recolorVariationPopupButton(sectionOrder);
 				}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/VariationPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/VariationPopup.java
@@ -354,7 +354,7 @@ public class VariationPopup {
 		keyChangePanel.setLayout(new BoxLayout(keyChangePanel, BoxLayout.X_AXIS));
 		keyChangeKnob.setInt(secC.getCustomKeyChange() == null ? 0 : secC.getCustomKeyChange());
 		keyChangeKnob.getKnob().setFunc(e -> {
-			secC.setCustomKeyChange(keyChangeKnob.getInt());
+			secC.setCustomKeyChange(keyChangeKnob.getValueRaw());
 		});
 		keyChangePanel.add(keyChangeKnob);
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/VisualArrayPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/VisualArrayPopup.java
@@ -27,7 +27,7 @@ public class VisualArrayPopup extends CloseablePopup {
 	JTextField text = null;
 	Consumer<Object> closeFunc = null;
 
-	public VisualArrayPopup(int min, int max, List<Integer> values) {
+	public VisualArrayPopup(int min, int max, List<Integer> values, boolean addButtons) {
 		super("Edit Multiple Values (Graphical)", 13, new Point(-300, 0));
 		mvea = new MultiValueEditArea(min, max, values);
 		mvea.setPop(this);
@@ -40,87 +40,90 @@ public class VisualArrayPopup extends CloseablePopup {
 		JPanel buttonPanel = new JPanel();
 		buttonPanel.setLayout(new GridLayout(0, 4, 0, 0));
 		buttonPanel.setPreferredSize(new Dimension(500, 50));
-		buttonPanel.add(VibeComposerGUI.makeButton("Add", e -> {
-			if (mvea.getValues().size() > 31) {
-				return;
-			}
-			mvea.getValues().add(0);
-			repaintMvea();
-		}));
-		buttonPanel.add(VibeComposerGUI.makeButton("Remove", e -> {
-			if (mvea.getValues().size() <= 1) {
-				return;
-			}
-			mvea.getValues().remove(mvea.getValues().size() - 1);
-			repaintMvea();
-		}));
-		buttonPanel.add(VibeComposerGUI.makeButton("Clear", e -> {
-			int size = mvea.getValues().size();
-			mvea.getValues().clear();
-			for (int i = 0; i < size; i++) {
+		if (addButtons) {
+			buttonPanel.add(VibeComposerGUI.makeButton("Add", e -> {
+				if (mvea.getValues().size() > 31) {
+					return;
+				}
 				mvea.getValues().add(0);
-			}
-			repaintMvea();
-		}));
-		buttonPanel.add(VibeComposerGUI.makeButton("2x", e -> {
-			if (mvea.getValues().size() > 16) {
-				return;
-			}
-			mvea.getValues().addAll(mvea.getValues());
-			repaintMvea();
-		}));
-		buttonPanel.add(VibeComposerGUI.makeButton("Dd", e -> {
-			if (mvea.getValues().size() > 16) {
-				return;
-			}
-			List<Integer> ddValues = new ArrayList<>();
-			List<Integer> oldValues = mvea.getValues();
-			oldValues.forEach(f -> {
-				ddValues.add(f);
-				ddValues.add(f);
-			});
-			oldValues.clear();
-			oldValues.addAll(ddValues);
-			repaintMvea();
-		}));
-		buttonPanel.add(VibeComposerGUI.makeButton("1/2", e -> {
-			if (mvea.getValues().size() <= 1) {
-				return;
-			}
-			int toRemain = (mvea.getValues().size() + 1) / 2;
-			for (int i = mvea.getValues().size() - 1; i >= toRemain; i--) {
-				mvea.getValues().remove(i);
-			}
-
-			repaintMvea();
-		}));
-		buttonPanel.add(VibeComposerGUI.makeButton("???", e -> {
-			int size = mvea.getValues().size();
-			boolean successRandGenerator = false;
-			if (butt != null && butt.getRandGenerator() != null) {
-				List<Integer> randValues = null;
-				try {
-					randValues = butt.getRandGenerator().apply(new Object());
-				} catch (Exception exc) {
-					LG.d("Random generator is not ready!");
+				repaintMvea();
+			}));
+			buttonPanel.add(VibeComposerGUI.makeButton("Remove", e -> {
+				if (mvea.getValues().size() <= 1) {
+					return;
 				}
-				if (randValues != null && !randValues.isEmpty()) {
-					mvea.getValues().clear();
-					mvea.getValues().addAll(randValues);
-					successRandGenerator = true;
-				}
-
-			}
-			if (!successRandGenerator) {
-				Random rnd = new Random();
+				mvea.getValues().remove(mvea.getValues().size() - 1);
+				repaintMvea();
+			}));
+			buttonPanel.add(VibeComposerGUI.makeButton("Clear", e -> {
+				int size = mvea.getValues().size();
 				mvea.getValues().clear();
 				for (int i = 0; i < size; i++) {
-					mvea.getValues().add(rnd.nextInt(max - min + 1) + min);
+					mvea.getValues().add(0);
 				}
-			}
+				repaintMvea();
+			}));
+			buttonPanel.add(VibeComposerGUI.makeButton("2x", e -> {
+				if (mvea.getValues().size() > 16) {
+					return;
+				}
+				mvea.getValues().addAll(mvea.getValues());
+				repaintMvea();
+			}));
+			buttonPanel.add(VibeComposerGUI.makeButton("Dd", e -> {
+				if (mvea.getValues().size() > 16) {
+					return;
+				}
+				List<Integer> ddValues = new ArrayList<>();
+				List<Integer> oldValues = mvea.getValues();
+				oldValues.forEach(f -> {
+					ddValues.add(f);
+					ddValues.add(f);
+				});
+				oldValues.clear();
+				oldValues.addAll(ddValues);
+				repaintMvea();
+			}));
+			buttonPanel.add(VibeComposerGUI.makeButton("1/2", e -> {
+				if (mvea.getValues().size() <= 1) {
+					return;
+				}
+				int toRemain = (mvea.getValues().size() + 1) / 2;
+				for (int i = mvea.getValues().size() - 1; i >= toRemain; i--) {
+					mvea.getValues().remove(i);
+				}
 
-			repaintMvea();
-		}));
+				repaintMvea();
+			}));
+			buttonPanel.add(VibeComposerGUI.makeButton("???", e -> {
+				int size = mvea.getValues().size();
+				boolean successRandGenerator = false;
+				if (butt != null && butt.getRandGenerator() != null) {
+					List<Integer> randValues = null;
+					try {
+						randValues = butt.getRandGenerator().apply(new Object());
+					} catch (Exception exc) {
+						LG.d("Random generator is not ready!");
+					}
+					if (randValues != null && !randValues.isEmpty()) {
+						mvea.getValues().clear();
+						mvea.getValues().addAll(randValues);
+						successRandGenerator = true;
+					}
+
+				}
+				if (!successRandGenerator) {
+					Random rnd = new Random();
+					mvea.getValues().clear();
+					for (int i = 0; i < size; i++) {
+						mvea.getValues().add(rnd.nextInt(max - min + 1) + min);
+					}
+				}
+
+				repaintMvea();
+			}));
+		}
+
 
 		buttonPanel.add(VibeComposerGUI.makeButton("> OK <", e -> close()));
 
@@ -129,29 +132,32 @@ public class VisualArrayPopup extends CloseablePopup {
 		mveaPanel.setMinimumSize(new Dimension(500, 500));
 		mveaPanel.add(mvea);
 
-		JPanel textPanel = new JPanel();
-		textPanel.setLayout(new BoxLayout(textPanel, BoxLayout.X_AXIS));
 		text = new JTextField(StringUtils.join(values, ","), 25);
-		textPanel.add(text);
-		textPanel.add(VibeComposerGUI.makeButton("Apply", e -> {
-			if (StringUtils.isNotEmpty(text.getText())) {
-				try {
-					String[] textSplit = text.getText().split(",");
-					List<Integer> nums = new ArrayList<>();
-					for (String s : textSplit) {
-						nums.add(Integer.valueOf(s));
-					}
-					mvea.getValues().clear();
-					mvea.getValues().addAll(nums);
-					repaintMvea();
-				} catch (Exception exc) {
-					LG.d("Incorrect text format, cannot convert to list of numbers.");
-				}
-			}
-		}));
-
 		allPanels.add(buttonPanel);
-		allPanels.add(textPanel);
+
+		if (addButtons) {
+			JPanel textPanel = new JPanel();
+			textPanel.setLayout(new BoxLayout(textPanel, BoxLayout.X_AXIS));
+			textPanel.add(text);
+			textPanel.add(VibeComposerGUI.makeButton("Apply", e -> {
+				if (StringUtils.isNotEmpty(text.getText())) {
+					try {
+						String[] textSplit = text.getText().split(",");
+						List<Integer> nums = new ArrayList<>();
+						for (String s : textSplit) {
+							nums.add(Integer.valueOf(s));
+						}
+						mvea.getValues().clear();
+						mvea.getValues().addAll(nums);
+						repaintMvea();
+					} catch (Exception exc) {
+						LG.d("Incorrect text format, cannot convert to list of numbers.");
+					}
+				}
+			}));
+			allPanels.add(textPanel);
+		}
+
 		allPanels.add(mveaPanel);
 		frame.add(allPanels);
 		frame.pack();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
@@ -58,7 +58,7 @@ public class Section {
 	}
 
 	public static final String[][] variationDescriptions = {
-			{ "#", "Incl.", "Transpose", "MaxJump" },
+			{ "#", "Incl.", "Transpose", "MaxJump", "Embellish" },
 			{ "#", "Incl.", "OffsetSeed", "RhythmPauses" },
 			{ "#", "Incl.", "Transpose", "IgnoreFill", "UpStretch", "No2nd", "MaxStrum" },
 			{ "#", "Incl.", "Transpose", "IgnoreFill", "RandOct", "FillLast", "ChordDir." },

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
@@ -53,8 +53,8 @@ import jm.music.data.Phrase;
 @XmlType(propOrder = {})
 public class Section {
 	public enum SectionType {
-		INTRO, VERSE1, VERSE2, VERSE3, CHORUS1, CHORUS2, HALF_CHORUS, BREAKDOWN, CHILL, BUILDUP,
-		CHORUS3, CLIMAX, OUTRO;
+		INTRO, VERSE1, VERSE2, VERSE3, CHORUS1, CHORUS2, HALF_CHORUS, BREAKDOWN, CHILL, BUILDUP1,
+		BUILDUP2, CHORUS3, CLIMAX, OUTRO;
 	}
 
 	public static final String[][] variationDescriptions = {
@@ -634,6 +634,7 @@ public class Section {
 		if (StringUtils.isEmpty(type)) {
 			return 0;
 		} else {
+			type = type.toUpperCase();
 			if (type.startsWith("CHORUS") || type.startsWith("CLIMAX")
 					|| type.startsWith("PREVIEW")) {
 				return 0;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
@@ -463,6 +463,9 @@ public class Section {
 	public List<Integer> getVariation(int part, int partOrder) {
 		initPartMapIfNull();
 		List<Integer> variations = new ArrayList<>();
+		if (partPresenceVariationMap.get(part).length <= partOrder) {
+			return variations;
+		}
 		for (int i = 2; i < partPresenceVariationMap.get(part)[partOrder].length; i++) {
 			if (partPresenceVariationMap.get(part)[partOrder][i] == Boolean.TRUE) {
 				variations.add(i - 2);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
@@ -58,7 +58,7 @@ public class Section {
 	}
 
 	public static final String[][] variationDescriptions = {
-			{ "#", "Incl.", "Transpose", "MaxJump", "Embellish" },
+			{ "#", "Incl.", "Transpose", "MaxJump", "Embellish", "Solo" },
 			{ "#", "Incl.", "OffsetSeed", "RhythmPauses" },
 			{ "#", "Incl.", "Transpose", "IgnoreFill", "UpStretch", "No2nd", "MaxStrum" },
 			{ "#", "Incl.", "Transpose", "IgnoreFill", "RandOct", "FillLast", "ChordDir." },

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -1606,10 +1606,10 @@ public class VibeComposerGUI extends JFrame
 		melodyPatternEffect.setSelectedIndex(2);
 		melodyPatternRandomizeOnCompose = makeCheckBox(
 				"<html>Randomize Pattern<br> on Compose</html>", true, true);
-		melodyRhythmAccents = new ScrollComboBox<>(true);
+		melodyRhythmAccents = new ScrollComboBox<>();
 		ScrollComboBox.addAll(new String[] { "None", "Snares", "Kicks", "Rides,OpenHH",
 				"Snares,Kicks", "Snares,Rides,OpenHH" }, melodyRhythmAccents);
-		melodyRhythmAccentsMode = new ScrollComboBox<>(true);
+		melodyRhythmAccentsMode = new ScrollComboBox<>();
 		ScrollComboBox.addAll(new String[] { "Mute", "Repitch", "Vol+", "---" },
 				melodyRhythmAccentsMode);
 		melodyRhythmAccentsPocket = new CustomCheckBox("Pocket", false);
@@ -4041,7 +4041,7 @@ public class VibeComposerGUI extends JFrame
 		macroParams.add(globalSwingPanel);
 
 
-		beatDurationMultiplier = new ScrollComboBox<Double>(false);
+		beatDurationMultiplier = new ScrollComboBox<Double>();
 		ScrollComboBox.addAll(new Double[] { 0.5, 1.0, 2.0 }, beatDurationMultiplier);
 		JPanel useDoubledPanel = new JPanel();
 		useDoubledPanel.add(new JLabel("Beat Dur. Multiplier"));

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -1610,7 +1610,8 @@ public class VibeComposerGUI extends JFrame
 		ScrollComboBox.addAll(new String[] { "None", "Snares", "Kicks", "Rides,OpenHH",
 				"Snares,Kicks", "Snares,Rides,OpenHH" }, melodyRhythmAccents);
 		melodyRhythmAccentsMode = new ScrollComboBox<>();
-		ScrollComboBox.addAll(new String[] { "Mute", "Repitch", "Vol+", "---" },
+		ScrollComboBox.addAll(
+				new String[] { "Mute", "Pitch+", "Pitch-", "Pitch~", "Vol+", "Vol-", "---" },
 				melodyRhythmAccentsMode);
 		melodyRhythmAccentsPocket = new CustomCheckBox("Pocket", false);
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -8041,6 +8041,9 @@ public class VibeComposerGUI extends JFrame
 		}
 		for (int i = 0; i < newPanels.size(); i++) {
 			newPanels.get(i).setFromInstPart(parts.get(i));
+			if (inst == 4 && newPanels.get(i).getComboPanel() != null) {
+				newPanels.get(i).getComboPanel().reapplyHits();
+			}
 		}
 		recalculateTabPaneCounts();
 		instrumentTabPane.repaint();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -4317,6 +4317,18 @@ public class VibeComposerGUI extends JFrame
 		});
 		customChordsPanel.add(limitChordsButton);
 
+		JButton melodifyChordsButton = new JButton(".M");
+		melodifyChordsButton.setPreferredSize(new Dimension(25, 25));
+		melodifyChordsButton.setMargin(new Insets(0, 0, 0, 0));
+		melodifyChordsButton.addActionListener(new ActionListener() {
+
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				userChords.conformToMelodyPattern(melodyPanels.get(0).getChordNoteChoices());
+			}
+		});
+		customChordsPanel.add(melodifyChordsButton);
+
 		userChordsDurations = new JTextField("4,4,4,4", 9);
 		JLabel userChordsDurationsLabel = new JLabel("Chord durations:");
 		customChordsPanel.add(userChordsDurationsLabel);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -6585,6 +6585,11 @@ public class VibeComposerGUI extends JFrame
 
 		boolean isCompose = "Compose".equals(ae.getActionCommand());
 		boolean isRegenerate = "Regenerate".equals(ae.getActionCommand());
+		if (composingInProgress) {
+			LG.i("Cannot process action '" + ae.getActionCommand() + "', composing in progress!");
+			new TemporaryInfoPopup("Composing in progress..", 500);
+			return;
+		}
 
 		InstComboBox.BANNED_INSTS.clear();
 		InstComboBox.BANNED_INSTS.addAll(Arrays.asList(bannedInsts.getText().split(",")));

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -484,6 +484,8 @@ public class VibeComposerGUI extends JFrame
 	JCheckBox melodyArpySurprises;
 	JCheckBox melodySingleNoteExceptions;
 	JCheckBox melodyFillPausesPerChord;
+	JCheckBox melodyLegacyMode;
+
 	JCheckBox melodyAvoidChordJumps;
 	JCheckBox melodyUseDirectionsFromProgression;
 	JCheckBox melodyPatternFlip;
@@ -1611,6 +1613,7 @@ public class VibeComposerGUI extends JFrame
 				true);
 		melodyFillPausesPerChord = new CustomCheckBox("<html>Fill Pauses<br>Per Chord</html>",
 				true);
+		melodyLegacyMode = new CustomCheckBox("<html>LEGACY<br>MODE</html>", false);
 		melodyAvoidChordJumps = new CustomCheckBox("<html>Avoid<br>Chord Jumps</html>", true);
 		melodyUseDirectionsFromProgression = new CustomCheckBox(
 				"<html>Use Chord<br>Directions</html>", false);
@@ -1651,6 +1654,7 @@ public class VibeComposerGUI extends JFrame
 		melodySettingsExtraPanelShape.add(melodyArpySurprises);
 		melodySettingsExtraPanelShape.add(melodySingleNoteExceptions);
 		melodySettingsExtraPanelShape.add(melodyFillPausesPerChord);
+		melodySettingsExtraPanelShape.add(melodyLegacyMode);
 		//melodySettingsExtraPanelShape.add(melodyAvoidChordJumps);
 
 		JPanel melodySettingsExtraPanelBlocksPatternsCompose = new JPanel();
@@ -7945,6 +7949,7 @@ public class VibeComposerGUI extends JFrame
 		gc.setMelodyArpySurprises(melodyArpySurprises.isSelected());
 		gc.setMelodySingleNoteExceptions(melodySingleNoteExceptions.isSelected());
 		gc.setMelodyFillPausesPerChord(melodyFillPausesPerChord.isSelected());
+		gc.setMelodyLegacyMode(melodyLegacyMode.isSelected());
 		gc.setMelodyUseDirectionsFromProgression(melodyUseDirectionsFromProgression.isSelected());
 		gc.setMelodyAvoidChordJumps(melodyAvoidChordJumps.isSelected());
 		gc.setMelodyBlockTargetMode(melodyBlockTargetMode.getSelectedIndex());
@@ -8081,6 +8086,7 @@ public class VibeComposerGUI extends JFrame
 		melodyArpySurprises.setSelected(gc.isMelodyArpySurprises());
 		melodySingleNoteExceptions.setSelected(gc.isMelodySingleNoteExceptions());
 		melodyFillPausesPerChord.setSelected(gc.isMelodyFillPausesPerChord());
+		melodyLegacyMode.setSelected(gc.isMelodyLegacyMode());
 		melodyAvoidChordJumps.setSelected(gc.isMelodyAvoidChordJumps());
 		melodyUseDirectionsFromProgression.setSelected(gc.isMelodyUseDirectionsFromProgression());
 		melodyBlockTargetMode.setSelectedIndex(gc.getMelodyBlockTargetMode());

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -1136,7 +1136,7 @@ public class VibeComposerGUI extends JFrame
 					recalculateTabPaneCounts();
 					recalculateGenerationCounts();
 					manualArrangement.setSelected(false);
-					midiMode.repaint();
+					vibeComposerGUI.repaint();
 				} catch (JAXBException | IOException e) {
 					// TODO Auto-generated catch block
 					e.printStackTrace();
@@ -6882,11 +6882,9 @@ public class VibeComposerGUI extends JFrame
 
 							unmarshallConfig(files[0]);
 					copyConfigToGUI(guiConfig);
-				} catch (JAXBException |
-
-						IOException e) {
-					// Auto-generated catch block
-					e.printStackTrace();
+					vibeComposerGUI.repaint();
+				} catch (JAXBException | IOException e) {
+					LG.e("Can't load config: " + filename, e);
 				}
 			}
 			soloMuterPossibleChange = true;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -5623,7 +5623,8 @@ public class VibeComposerGUI extends JFrame
 
 		cleanUpUIAfterCompose(regenerate);
 
-		if (configHistoryStoreRegeneratedTracks.isSelected() || !regenerate) {
+		if (configHistoryStoreRegeneratedTracks.isSelected() || !regenerate
+				|| configHistory.getItemCount() == 0) {
 			midiConfig.setCustomChords(StringUtils.join(MidiGenerator.chordInts, ","));
 			midiConfig.setRegenerateCount(regenerateCount);
 			configHistory.addItem(midiConfig);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -4324,7 +4324,7 @@ public class VibeComposerGUI extends JFrame
 
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				userChords.conformToMelodyPattern(melodyPanels.get(0).getChordNoteChoices());
+				userChords.alignWithMelodyTargetNotes(melodyPanels.get(0).getChordNoteChoices());
 			}
 		});
 		customChordsPanel.add(melodifyChordsButton);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -528,7 +528,6 @@ public class VibeComposerGUI extends JFrame
 	KnobPanel randomArpStretchGenerationChance;
 	KnobPanel randomArpMaxExceptionChance;
 	JCheckBox randomArpUseOctaveAdjustments;
-	KnobPanel randomArpMaxSwing;
 	KnobPanel randomArpMaxRepeat;
 	KnobPanel randomArpMinVel;
 	KnobPanel randomArpMaxVel;
@@ -2072,7 +2071,6 @@ public class VibeComposerGUI extends JFrame
 		randomArpUseChordFill = new CustomCheckBox("Fills", true);
 		randomArpShiftChance = new DetachedKnobPanel("Shift%", 50);
 		randomArpUseOctaveAdjustments = new CustomCheckBox("Rand. Oct.", false);
-		randomArpMaxSwing = new KnobPanel("Swing%", 50);
 		randomArpMaxRepeat = new DetachedKnobPanel("Max<br>Repeat", 2, 1, 4);
 		randomArpMinVel = new DetachedKnobPanel("Min<br>Vel", 65, 0, 126);
 		randomArpMaxVel = new DetachedKnobPanel("Max<br>Vel", 90, 1, 127);
@@ -2119,7 +2117,6 @@ public class VibeComposerGUI extends JFrame
 		arpSettingsExtraPanel.add(randomArpAllSameInst);
 		arpSettingsExtraPanel.add(randomArpLimitPowerOfTwo);
 		arpSettingsExtraPanel.add(randomArpUseOctaveAdjustments);
-		arpSettingsExtraPanel.add(randomArpMaxSwing);
 		arpSettingsExtraPanel.add(randomArpMaxRepeat);
 		arpSettingsExtraPanel.add(randomArpMinVel);
 		arpSettingsExtraPanel.add(randomArpMaxVel);
@@ -3997,14 +3994,13 @@ public class VibeComposerGUI extends JFrame
 
 	private void applyGlobalSwing(int swing, boolean customPanels) {
 		if (customPanels) {
-			getAffectedPanels(0).forEach(e -> e.setSwingPercent(swing));
-			getAffectedPanels(4).forEach(e -> e.setSwingPercent(swing));
+			for (int i = 0; i < 5; i++) {
+				getAffectedPanels(i).forEach(e -> e.setSwingPercent(swing));
+			}
 		} else {
-			melodyPanels.forEach(e -> e.setSwingPercent(swing));
-			randomArpMaxSwing.setInt(swing);
-			drumPanels.forEach(e -> {
-				e.setSwingPercent(swing);
-			});
+			for (int i = 0; i < 5; i++) {
+				getInstList(i).forEach(e -> e.setSwingPercent(swing));
+			}
 		}
 
 	}
@@ -7753,7 +7749,6 @@ public class VibeComposerGUI extends JFrame
 
 		// arps
 		gc.setUseOctaveAdjustments(randomArpUseOctaveAdjustments.isSelected());
-		gc.setMaxArpSwing(randomArpMaxSwing.getInt());
 
 		// drums
 		boolean isCustomMidiDevice = midiMode.isSelected()
@@ -7887,7 +7882,6 @@ public class VibeComposerGUI extends JFrame
 
 		// arps
 		randomArpUseOctaveAdjustments.setSelected(gc.isUseOctaveAdjustments());
-		randomArpMaxSwing.setInt(gc.getMaxArpSwing());
 
 		arrSection.setVisible(true);
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -7634,7 +7634,6 @@ public class VibeComposerGUI extends JFrame
 		mar.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
 		DrumPartsWrapper wrapper = new DrumPartsWrapper();
 		List<DrumPart> parts = (List<DrumPart>) (List<?>) getInstPartsFromInstPanels(4, false);
-		InstPart.sortParts(parts);
 		wrapper.setDrumParts(parts);
 		mar.marshal(wrapper, new File(path));
 		LG.i("File saved: " + path);
@@ -8240,6 +8239,7 @@ public class VibeComposerGUI extends JFrame
 				parts.add(p.toInstPart(lastRandomSeed));
 			}
 		}
+		InstPart.sortParts(parts);
 		return parts;
 	}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -221,6 +221,7 @@ public class VibeComposerGUI extends JFrame
 
 	private static final long serialVersionUID = -677536546851756969L;
 
+	private static final String BUG_HUNT_MESSAGE = "You found a bug! Save your project as a new preset, and send the .xml to my email: vibehistorian@gmail.com!";
 	private static final String FILENAME_VALID_CHARACTERS = "[a-zA-Z0-9,\\-_']";
 	private static final String FILENAME_VALID_NAME = "^" + FILENAME_VALID_CHARACTERS + "+$";
 	private static final String MIDIS_FOLDER = "midis";
@@ -5633,7 +5634,16 @@ public class VibeComposerGUI extends JFrame
 
 		// unapply S/M, generate, reapply S/M with new track numbering
 		unapplySolosMutes(true);
-		melodyGen.generateMasterpiece(masterpieceSeed, relPath);
+		try {
+			melodyGen.generateMasterpiece(masterpieceSeed, relPath);
+		} catch (Exception e) {
+			LG.e("Exception during midi generation! Cause: " + e.getMessage());
+			composingInProgress = false;
+			new TemporaryInfoPopup(BUG_HUNT_MESSAGE, null);
+			reapplySolosMutes();
+			return;
+		}
+
 		guiConfig = midiConfig;
 		//LG.i("Adding to config history, reason: " + regenerate);
 		fixCombinedTracks();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -561,7 +561,7 @@ public class VibeComposerGUI extends JFrame
 	public static JCheckBox sidechainPatternsOnCompose;
 	JCheckBox arrangementResetCustomPanelsOnCompose;
 	ScrollComboBox<String> randomDrumHitsMultiplier;
-	int randomDrumHitsMultiplierLastState = 1;
+	ScrollComboBox<String> randomDrumHitsMultiplierOnGenerate;
 	public static JCheckBox drumCustomMapping;
 	public static JTextField drumCustomMappingNumbers;
 
@@ -2239,9 +2239,14 @@ public class VibeComposerGUI extends JFrame
 		drumsPanel.add(randomDrumUseChordFill);
 
 		randomDrumHitsMultiplier = new ScrollComboBox<>();
-		ScrollComboBox.addAll(new String[] { OMNI.EMPTYCOMBO, "0.5x", "1.5x", "2x" },
+		ScrollComboBox.addAll(new String[] { OMNI.EMPTYCOMBO, "0.5x", "0.75x", "1.5x", "2x" },
 				randomDrumHitsMultiplier);
 		randomDrumHitsMultiplier.setVal(OMNI.EMPTYCOMBO);
+		randomDrumHitsMultiplierOnGenerate = new ScrollComboBox<>(false);
+		ScrollComboBox.addAll(new String[] { OMNI.EMPTYCOMBO, "0.5x", "0.75x", "1.5x", "2x" },
+				randomDrumHitsMultiplierOnGenerate);
+		randomDrumHitsMultiplierOnGenerate.setVal(OMNI.EMPTYCOMBO);
+
 		randomDrumHitsMultiplier.addItemListener(new ItemListener() {
 
 			@Override
@@ -2257,14 +2262,16 @@ public class VibeComposerGUI extends JFrame
 							affectedDrums.get(i).setHitsPerPattern(newHits / 2);
 							break;
 						case 2:
-							affectedDrums.get(i).setHitsPerPattern(newHits * 3 / 2);
+							affectedDrums.get(i).setHitsPerPattern(newHits * 3 / 4);
 							break;
 						case 3:
+							affectedDrums.get(i).setHitsPerPattern(newHits * 3 / 2);
+							break;
+						case 4:
 							affectedDrums.get(i).setHitsPerPattern(newHits * 2);
 							break;
 						default:
-							throw new IllegalArgumentException(
-									"Only 3 hits multiplier states allowed!");
+							throw new IllegalArgumentException("Multiplier too high!");
 						}
 						if (randomDrumHitsMultiplier.getSelectedIndex() > 1
 								&& affectedDrums.get(i).getPattern() == RhythmPattern.CUSTOM) {
@@ -2283,8 +2290,10 @@ public class VibeComposerGUI extends JFrame
 			}
 		});
 
-		drumsPanel.add(new JLabel("Hits Multiplier:"));
+		drumsPanel.add(new JLabel("Multiply Hits By"));
 		drumsPanel.add(randomDrumHitsMultiplier);
+		drumsPanel.add(new JLabel("On Generate"));
+		drumsPanel.add(randomDrumHitsMultiplierOnGenerate);
 		drumsPanel.add(randomDrumSlide);
 		drumPartPresetBox = new ScrollComboBox<>();
 		ScrollComboBox.addAll(new String[] { OMNI.EMPTYCOMBO }, drumPartPresetBox);
@@ -7472,7 +7481,7 @@ public class VibeComposerGUI extends JFrame
 		cs.add(melodyPatternRandomizeOnCompose);
 		cs.add(melodyTargetNotesRandomizeOnCompose);
 
-		// bass panel - nothing
+		// bass panel
 
 		// chord panel
 		cs.add(randomChordsGenerateOnCompose);
@@ -7570,6 +7579,19 @@ public class VibeComposerGUI extends JFrame
 		cs.add(customFilenameAddTimestamp);
 		cs.add(configHistoryStoreRegeneratedTracks);
 		cs.add(sidechainPatternsOnCompose);
+
+		// ---------------- VIBECOMPOSER 2 ------------------------------------
+
+		// melody panel
+
+		// bass panel
+
+		// chords panel
+
+		// arps panel
+
+		// drum panel
+		cs.add(randomDrumHitsMultiplierOnGenerate);
 
 		return cs;
 	}
@@ -8245,6 +8267,24 @@ public class VibeComposerGUI extends JFrame
 
 			dpart.setOrder(ip.getPanelOrder());
 			dpart.setMuted(ip.getMuteInst());
+			switch (randomDrumHitsMultiplierOnGenerate.getSelectedIndex()) {
+			case 0:
+				break;
+			case 1:
+				dpart.setHitsPerPattern(dpart.getHitsPerPattern() / 2);
+				break;
+			case 2:
+				dpart.setHitsPerPattern(dpart.getHitsPerPattern() * 3 / 4);
+				break;
+			case 3:
+				dpart.setHitsPerPattern(dpart.getHitsPerPattern() * 3 / 2);
+				break;
+			case 4:
+				dpart.setHitsPerPattern(dpart.getHitsPerPattern() * 2);
+				break;
+			default:
+				throw new IllegalArgumentException("Multiplier index too high.");
+			}
 			ip.setFromInstPart(dpart);
 
 			//dp.setHitsPerPattern(dp.getHitsPerPattern() * randomDrumHitsMultiplierLastState);
@@ -8412,6 +8452,24 @@ public class VibeComposerGUI extends JFrame
 				hits /= 2;
 			}
 
+			switch (randomDrumHitsMultiplierOnGenerate.getSelectedIndex()) {
+			case 0:
+				break;
+			case 1:
+				hits /= 2;
+				break;
+			case 2:
+				hits = hits * 3 / 4;
+				break;
+			case 3:
+				hits = hits * 3 / 2;
+				break;
+			case 4:
+				hits *= 2;
+				break;
+			default:
+				throw new IllegalArgumentException("Multiplier index too high.");
+			}
 			ip.setHitsPerPattern(hits * 2);
 
 			int adjustVelocity = -1 * ip.getHitsPerPattern() / ip.getChordSpan();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -6074,10 +6074,16 @@ public class VibeComposerGUI extends JFrame
 			}
 
 			sequencer.start();  // start the playback
-
+			double divisor = 1;
+			if (beatDurationMultiplier.getSelectedIndex() == 0) {
+				divisor = 0.5;
+			} else if (beatDurationMultiplier.getSelectedIndex() == 2) {
+				divisor = 2;
+			}
 			loopBeatCount.getKnob()
 					.setMax(!MidiGenerator.userChordsDurations.isEmpty()
-							? (int) Math.ceil(OMNI.sumListDouble(MidiGenerator.userChordsDurations))
+							? (int) Math.ceil(
+									OMNI.sumListDouble(MidiGenerator.userChordsDurations) / divisor)
 							: MidiGenerator.chordInts.size() * 4);
 			startMidiCcThread();
 			recalculateTabPaneCounts();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -243,8 +243,18 @@ public class VibeComposerGUI extends JFrame
 	private static final String[] LOCK_COMPONENT_ICON_NAMES = new String[] { "lock.png",
 			"toggle_lock.png", "lock_white.png", "toggle_lock_white.png" };
 
-	public static final int[] MILISECOND_ARRAY_STRUM = { 0, 31, 62, 125, 125, 250, 333, 500, 666,
-			750, 1000, 1500, 2000 };
+	public static final int[] MILISECOND_ARRAY_STRUM = { 0, 31, 62, 125, 250, 333, 375, 500, 666,
+			750, 1000, 1333, 1500, 2000 };
+	public static final List<Integer> MILISECOND_LIST_STRUM = Arrays.stream(MILISECOND_ARRAY_STRUM)
+			.mapToObj(e -> Integer.valueOf(e)).collect(Collectors.toList());
+
+	public static final int[] MILISECOND_ARRAY_FEEDBACK = { -2000, -1500, -1333, -1000, -750, -666,
+			-500, -375, -333, -250, -125, -62, -31, 0, 31, 62, 125, 250, 333, 375, 500, 666, 750,
+			1000, 1333, 1500, 2000 };
+	public static final List<Integer> MILISECOND_LIST_FEEDBACK = Arrays
+			.stream(MILISECOND_ARRAY_FEEDBACK).mapToObj(e -> Integer.valueOf(e))
+			.collect(Collectors.toList());
+
 	public static final int[] MILISECOND_ARRAY_DELAY = { 0, 62, 125, 250, 333 };
 	public static final int[] MILISECOND_ARRAY_SPLIT = { 625, 750, 875 };
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -9558,4 +9558,29 @@ public class VibeComposerGUI extends JFrame
 		}
 		return Pair.of(lastMode, lastKeyChange);
 	}
+
+	public static boolean isSingleSolo() {
+		int groupIndex = -1;
+		for (int i = 0; i < groupSoloMuters.size(); i++) {
+			if (groupSoloMuters.get(i).soloState != State.OFF) {
+				if (groupIndex >= 0) {
+					return false;
+				}
+				groupIndex = i;
+			}
+		}
+		if (groupIndex < 0) {
+			return false;
+		}
+		boolean foundSolo = false;
+		for (InstPanel ip : getInstList(groupIndex)) {
+			if (ip.getSoloMuter().soloState != State.OFF) {
+				if (foundSolo) {
+					return false;
+				}
+				foundSolo = true;
+			}
+		}
+		return foundSolo;
+	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -479,6 +479,8 @@ public class VibeComposerGUI extends JFrame
 	JCheckBox melodyTargetNotesRandomizeOnCompose;
 	ScrollComboBox<String> melodyPatternEffect;
 	ScrollComboBox<String> melodyRhythmAccents;
+	ScrollComboBox<String> melodyRhythmAccentsMode;
+	JCheckBox melodyRhythmAccentsPocket;
 	JCheckBox melodyPatternRandomizeOnCompose;
 	KnobPanel melodyReplaceAvoidNotes;
 	KnobPanel melodyMaxDirChanges;
@@ -1604,9 +1606,13 @@ public class VibeComposerGUI extends JFrame
 		melodyPatternEffect.setSelectedIndex(2);
 		melodyPatternRandomizeOnCompose = makeCheckBox(
 				"<html>Randomize Pattern<br> on Compose</html>", true, true);
-		melodyRhythmAccents = new ScrollComboBox<>(false);
+		melodyRhythmAccents = new ScrollComboBox<>(true);
 		ScrollComboBox.addAll(new String[] { "None", "Snares", "Kicks", "Rides,OpenHH",
 				"Snares,Kicks", "Snares,Rides,OpenHH" }, melodyRhythmAccents);
+		melodyRhythmAccentsMode = new ScrollComboBox<>(true);
+		ScrollComboBox.addAll(new String[] { "Mute", "Repitch", "Vol+", "---" },
+				melodyRhythmAccentsMode);
+		melodyRhythmAccentsPocket = new CustomCheckBox("Pocket", false);
 
 		melodyReplaceAvoidNotes = new KnobPanel("Replace<br>Avoid Notes", 2, 0, 2);
 		melodyMaxDirChanges = new KnobPanel("Max. Dir.<br>Changes", 2, 1, 6);
@@ -1635,15 +1641,21 @@ public class VibeComposerGUI extends JFrame
 
 
 		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyUseDirectionsFromProgression);
-		melodySettingsExtraPanelBlocksPatternsCompose.add(new JLabel("Target Mode"));
+		melodySettingsExtraPanelBlocksPatternsCompose
+				.add(new JLabel("<html>Note Target<br>Mode</html>"));
 		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyBlockTargetMode);
 		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyTargetNotesRandomizeOnCompose);
 		melodySettingsExtraPanelBlocksPatternsCompose.add(new JLabel("Pattern Effect"));
 		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyPatternEffect);
 		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyPatternRandomizeOnCompose);
-		melodySettingsExtraPanelBlocksPatternsCompose
-				.add(new JLabel("<html>Drum Rhythm Accents<br>(Post-process)</html>"));
-		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyRhythmAccents);
+		JPanel postProcessPanel = new JPanel();
+		postProcessPanel.setBorder(BorderFactory.createBevelBorder(BevelBorder.LOWERED));
+		postProcessPanel.add(new JLabel("<html>Drum Rhythm Accents<br>(Post-process)</html>"));
+		postProcessPanel.add(melodyRhythmAccents);
+		postProcessPanel.add(new JLabel("Mode"));
+		postProcessPanel.add(melodyRhythmAccentsMode);
+		postProcessPanel.add(melodyRhythmAccentsPocket);
+		melodySettingsExtraPanelBlocksPatternsCompose.add(postProcessPanel);
 
 		JPanel melodySettingsExtraPanelOrg = new JPanel();
 		melodySettingsExtraPanelOrg.setBorder(BorderFactory.createBevelBorder(BevelBorder.RAISED));
@@ -7882,6 +7894,8 @@ public class VibeComposerGUI extends JFrame
 		gc.setMelodyBlockTargetMode(melodyBlockTargetMode.getSelectedIndex());
 		gc.setMelodyPatternEffect(melodyPatternEffect.getSelectedIndex());
 		gc.setMelodyRhythmAccents(melodyRhythmAccents.getSelectedIndex());
+		gc.setMelodyRhythmAccentsMode(melodyRhythmAccentsMode.getSelectedIndex());
+		gc.setMelodyRhythmAccentsPocket(melodyRhythmAccentsPocket.isSelected());
 		gc.setMelodyReplaceAvoidNotes(melodyReplaceAvoidNotes.getInt());
 		gc.setMelodyMaxDirChanges(melodyMaxDirChanges.getInt());
 		gc.setMelodyTargetNoteVariation(melodyTargetNoteVariation.getInt());
@@ -8016,6 +8030,8 @@ public class VibeComposerGUI extends JFrame
 		melodyBlockTargetMode.setSelectedIndex(gc.getMelodyBlockTargetMode());
 		melodyPatternEffect.setSelectedIndex(gc.getMelodyPatternEffect());
 		melodyRhythmAccents.setSelectedIndex(gc.getMelodyRhythmAccents());
+		melodyRhythmAccentsMode.setSelectedIndex(gc.getMelodyRhythmAccentsMode());
+		melodyRhythmAccentsPocket.setSelected(gc.isMelodyRhythmAccentsPocket());
 		melodyReplaceAvoidNotes.setInt(gc.getMelodyReplaceAvoidNotes());
 		melodyMaxDirChanges.setInt(gc.getMelodyMaxDirChanges());
 		melodyTargetNoteVariation.setInt(gc.getMelodyTargetNoteVariation());

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -2516,9 +2516,7 @@ public class VibeComposerGUI extends JFrame
 			//actualArrangement.resortByIndexes(scrollableArrangementActualTable);
 			Integer secOrder = Integer.valueOf(action.split(",")[1]);
 			openVariationPopup(secOrder);
-			refreshActual = true;
-			resetArrSectionSelection = false;
-			resetArrSectionPanel = false;
+			return;
 			//variationJD.getFrame().setTitle(action);
 		} else if (action.startsWith("ArrangementApply")) {
 			String selItem = arrSection.getVal();
@@ -3728,9 +3726,13 @@ public class VibeComposerGUI extends JFrame
 
 				}
 			};
-			butt.addActionListener(this);
-			butt.setActionCommand("ArrangementOpenVariation," + (i + 1));
-			//makeButton(, );
+			butt.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					openVariationPopup(fI + 1);
+
+				}
+			});
 
 			int width = Math.max(TABLE_COLUMN_MIN_WIDTH,
 					(scrollPaneDimension.width - arrangementRowHeaderWidth) / count);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -4035,7 +4035,7 @@ public class VibeComposerGUI extends JFrame
 
 		JPanel globalSwingPanel = new JPanel();
 		globalSwingOverride = new CustomCheckBox("<html>Global Swing<br>Override</html>", true);
-		globalSwingOverrideValue = new DetachedKnobPanel("", 50);
+		globalSwingOverrideValue = new KnobPanel("", 50);
 		globalSwingOverrideApplyButton = new JButton("A");
 		globalSwingOverrideApplyButton.addActionListener(new ActionListener() {
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -404,6 +404,7 @@ public class VibeComposerGUI extends JFrame
 	public static boolean copyDragging = false;
 	public static Triple<Integer, Integer, Integer> highlightedTableCell = null;
 	public static Triple<Integer, Integer, Integer> copyDraggingOrigin = null;
+	public static Point arrangementActualTableMousePoint = null;
 	PhraseNotes copyDraggedNotes = null;
 
 	// instrument global settings
@@ -3115,6 +3116,7 @@ public class VibeComposerGUI extends JFrame
 			public void mouseMoved(MouseEvent e) {
 				boolean repaintAnyway = highlightedTableCell != null;
 				highlightedTableCell = calculateCurrentTableSubcell(e);
+				arrangementActualTableMousePoint = new Point(e.getPoint());
 				if (highlightedTableCell != null || repaintAnyway) {
 					scrollableArrangementActualTable.repaint();
 				}
@@ -3124,6 +3126,7 @@ public class VibeComposerGUI extends JFrame
 			public void mouseDragged(MouseEvent e) {
 				boolean repaintAnyway = highlightedTableCell != null;
 				highlightedTableCell = calculateCurrentTableSubcell(e);
+				arrangementActualTableMousePoint = new Point(e.getPoint());
 				if (highlightedTableCell != null || repaintAnyway) {
 					scrollableArrangementActualTable.repaint();
 				}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -221,6 +221,8 @@ public class VibeComposerGUI extends JFrame
 
 	private static final long serialVersionUID = -677536546851756969L;
 
+	private static final String FILENAME_VALID_CHARACTERS = "[a-zA-Z0-9,\\-_']";
+	private static final String FILENAME_VALID_NAME = "^" + FILENAME_VALID_CHARACTERS + "+$";
 	private static final String MIDIS_FOLDER = "midis";
 	private static final String DRUMS_FOLDER = "drums";
 	private static final String MIDI_HISTORY_FOLDER = MIDIS_FOLDER + "/midi_history";
@@ -1148,7 +1150,9 @@ public class VibeComposerGUI extends JFrame
 	private void savePreset() {
 		String presetName = (String) presetLoadBox.getEditor().getItem();
 		LG.i("Trying to save preset: " + presetName);
-		if (!StringUtils.isAlphanumeric(presetName)) {
+		if (!presetName.matches(FILENAME_VALID_NAME)) {
+			new TemporaryInfoPopup("Name contains invalid characters: "
+					+ presetName.replaceAll(FILENAME_VALID_CHARACTERS, ""), 2500);
 			return;
 		}
 		File makeSavedDir = new File(PRESET_FOLDER);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -2321,6 +2321,8 @@ public class VibeComposerGUI extends JFrame
 								&& affectedDrums.get(i).getPattern() == RhythmPattern.CUSTOM) {
 							List<Integer> trueSub = affectedDrums.get(i).getComboPanel()
 									.getTruePattern().subList(0, newHits);
+							Collections.rotate(trueSub, affectedDrums.get(i).getPatternShift());
+							affectedDrums.get(i).setPatternShift(0);
 							while (trueSub.size() < VisualPatternPanel.MAX_HITS) {
 								trueSub.addAll(trueSub);
 							}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -4705,6 +4705,7 @@ public class VibeComposerGUI extends JFrame
 						}
 					} catch (Exception e) {
 						LG.e("Exception in SEQUENCE SLIDER:");
+						composingInProgress = false;
 						LG.e(e.getMessage());
 						e.printStackTrace();
 						try {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -124,6 +124,7 @@ import javax.swing.Timer;
 import javax.swing.UIManager;
 import javax.swing.WindowConstants;
 import javax.swing.border.BevelBorder;
+import javax.swing.border.SoftBevelBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.ListSelectionEvent;
@@ -1018,7 +1019,7 @@ public class VibeComposerGUI extends JFrame
 		extraSettingsPanel = new JPanel();
 		extraSettingsPanel.setLayout(new BoxLayout(extraSettingsPanel, BoxLayout.Y_AXIS));
 
-		mainButtonsPanel.add(makeButton("Extra", e -> openExtraSettingsPopup()));
+		mainButtonsPanel.add(makeButton("Settings", e -> openExtraSettingsPopup()));
 
 
 		// ---- MESSAGE PANEL ----
@@ -1135,7 +1136,7 @@ public class VibeComposerGUI extends JFrame
 
 	private void initExtraSettings() {
 		JPanel arrangementExtraSettingsPanel = new JPanel();
-
+		arrangementExtraSettingsPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 		arrangementScaleMidiVelocity = new CustomCheckBox("Scale Midi Velocity in Arrangement",
 				true);
 		arrangementResetCustomPanelsOnCompose = makeCheckBox("Reset customized panels On Compose",
@@ -1150,6 +1151,7 @@ public class VibeComposerGUI extends JFrame
 		//arrangementExtraSettingsPanel.add(bt);
 
 		JPanel humanizationPanel = new JPanel();
+		humanizationPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 
 		// / 10000
 		humanizeNotes = new DetachedKnobPanel("Humanize Notes<br>/10000", 150, 0, 1000);
@@ -1176,6 +1178,7 @@ public class VibeComposerGUI extends JFrame
 		humanizationPanel.add(sidechainPatternsOnCompose);
 
 		JPanel scalePanel = new JPanel();
+		scalePanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 		scalePanel.add(customMidiForceScale);
 		scalePanel.add(transposedNotesForceScale);
 
@@ -1183,11 +1186,12 @@ public class VibeComposerGUI extends JFrame
 		extraSettingsPanel.add(humanizationPanel);
 		extraSettingsPanel.add(scalePanel);
 
-		//JPanel loopBeatExtraSettingsPanel = new JPanel();
+		//JPanel loopBeatExtraSettingsPanel = new JPanel();arrangementExtraSettingsPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 		//loopBeatExtraSettingsPanel.add(loopBeatCompose);
 		//extraSettingsPanel.add(loopBeatExtraSettingsPanel);
 
 		JPanel allInstsPanel = new JPanel();
+		allInstsPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 		useAllInsts = new CustomCheckBox("Use All Inst., Except:", false);
 		allInstsPanel.add(useAllInsts);
 		bannedInsts = new JTextField("", 8);
@@ -1198,6 +1202,7 @@ public class VibeComposerGUI extends JFrame
 
 
 		JPanel pauseBehaviorPanel = new JPanel();
+		pauseBehaviorPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 		pauseBehaviorLabel = new JLabel("Start From Pause:");
 		pauseBehaviorCombobox = new ScrollComboBox<>(false);
 		startFromBar = new CustomCheckBox("Start From Bar", true);
@@ -1225,6 +1230,7 @@ public class VibeComposerGUI extends JFrame
 		pauseBehaviorPanel.add(moveStartToCustomizedSection);
 
 		JPanel customDrumMappingPanel = new JPanel();
+		customDrumMappingPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 		drumCustomMapping = new CustomCheckBox("Custom Drum Mapping", true);
 		drumCustomMappingNumbers = new JTextField(
 				StringUtils.join(InstUtils.DRUM_INST_NUMBERS_SEMI, ","));
@@ -1250,6 +1256,7 @@ public class VibeComposerGUI extends JFrame
 		keyChangeTypeSelection.addItemListener(this);
 
 		JPanel chordChoicePanel = new JPanel();
+		chordChoicePanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 		spiceFlattenBigChords = new CustomCheckBox("Spicy Voicing", false);
 		useChordFormula = new CustomCheckBox("Chord Formula", true);
 		randomChordVoicingChance = new KnobPanel("Flatten<br>Voicing%", 100);
@@ -1268,6 +1275,7 @@ public class VibeComposerGUI extends JFrame
 		extraSettingsPanel.add(chordChoicePanel);
 
 		JPanel bpmLowHighPanel = new JPanel();
+		bpmLowHighPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 
 		arpAffectsBpm = new CustomCheckBox("BPM slowed by ARP", false);
 		bpmLow = new DetachedKnobPanel("Min<br>BPM.", 50, 20, 249);
@@ -1307,12 +1315,14 @@ public class VibeComposerGUI extends JFrame
 			}
 		});
 		JPanel soundbankPanel = new JPanel();
+		soundbankPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 		JLabel soundbankLabel = new JLabel("Soundbank name:");
 		soundbankPanel.add(soundbankLabel);
 		soundbankPanel.add(soundbankFilename);
 		extraSettingsPanel.add(soundbankPanel);
 
 		JPanel displayStylePanel = new JPanel();
+		displayStylePanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 		displayVeloRectValues = new CustomCheckBox("Display Bar Values", true);
 		knobControlByDragging = new CustomCheckBox("Knob Up-Down Control", false);
 		highlightPatterns = new CustomCheckBox("Highlight Sequencer Pattern (-Perf)", true);
@@ -1353,6 +1363,7 @@ public class VibeComposerGUI extends JFrame
 
 
 		JPanel panelGenerationSettingsPanel = new JPanel();
+		panelGenerationSettingsPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 		bottomUpReverseDrumPanels = new CustomCheckBox("Bottom-Top Drum Display", false);
 		bottomUpReverseDrumPanels.addChangeListener(new ChangeListener() {
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -249,8 +249,8 @@ public class VibeComposerGUI extends JFrame
 			.mapToObj(e -> Integer.valueOf(e)).collect(Collectors.toList());
 
 	public static final int[] MILISECOND_ARRAY_FEEDBACK = { -2000, -1500, -1333, -1000, -750, -666,
-			-500, -375, -333, -250, -125, -62, -31, 0, 31, 62, 125, 250, 333, 375, 500, 666, 750,
-			1000, 1333, 1500, 2000 };
+			-500, -375, -333, -250, -125, -62, -31, 31, 62, 125, 250, 333, 375, 500, 666, 750, 1000,
+			1333, 1500, 2000 };
 	public static final List<Integer> MILISECOND_LIST_FEEDBACK = Arrays
 			.stream(MILISECOND_ARRAY_FEEDBACK).mapToObj(e -> Integer.valueOf(e))
 			.collect(Collectors.toList());

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -6211,13 +6211,18 @@ public class VibeComposerGUI extends JFrame
 				&& notExcludedDrum.isPresent()) ? notExcludedDrum.get().getSequenceTrack() : null;
 		for (int i = 0; i < 5; i++) {
 			List<? extends InstPanel> panels = getInstList(i);
+
+			if (!isEnabled(i)) {
+				continue;
+			}
+
 			if (i == 4 && notExcludedCombinedDrumTrack != null) {
 				// combined midi tracks -> unsolo drums
 				continue;
 			}
 			for (int j = 0; j < panels.size(); j++) {
 				Integer seqTrack = panels.get(j).getSequenceTrack();
-				if (seqTrack < 0) {
+				if (seqTrack < 0 || panels.get(j).getMuteInst()) {
 					continue;
 				}
 				if (panels.get(j).getSoloMuter().soloState == State.FULL) {
@@ -6259,10 +6264,18 @@ public class VibeComposerGUI extends JFrame
 		// set by soloState/muteState
 		for (int i = 0; i < 5; i++) {
 			List<? extends InstPanel> panels = getInstList(i);
-			panels.forEach(e -> sequencer.setTrackSolo(e.getSequenceTrack(),
-					e.getSoloMuter().soloState == State.FULL));
-			panels.forEach(e -> sequencer.setTrackMute(e.getSequenceTrack(),
-					e.getSoloMuter().muteState == State.FULL));
+			for (int j = 0; j < panels.size(); j++) {
+				InstPanel ip = panels.get(j);
+				if (ip.getSequenceTrack() < 0) {
+					ip.getSoloMuter().unsolo();
+					ip.getSoloMuter().unmute();
+				} else {
+					sequencer.setTrackSolo(ip.getSequenceTrack(),
+							ip.getSoloMuter().soloState == State.FULL);
+					sequencer.setTrackMute(ip.getSequenceTrack(),
+							ip.getSoloMuter().muteState == State.FULL);
+				}
+			}
 		}
 
 		Optional<DrumPanel> notExcludedDrum = drumPanels.stream()

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -1814,7 +1814,7 @@ public class VibeComposerGUI extends JFrame
 			melodyPanels.add(melodyPanel);
 			melodyPanel.setPanelOrder(i + 1);
 			if (i > 0) {
-
+				melodyPanel.setAccents(50);
 				melodyPanel.setFillPauses(true);
 				melodyPanel.setSpeed(0);
 				melodyPanel.setPauseChance(70);
@@ -1836,6 +1836,7 @@ public class VibeComposerGUI extends JFrame
 				}
 				melodyPanel.getVolSlider().setValue(45);
 			} else {
+				melodyPanel.setAccents(75);
 				melodyPanel.setFillPauses(false);
 				melodyPanel.setSpeed(15);
 				melodyPanel.setPauseChance(15);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -5554,7 +5554,7 @@ public class VibeComposerGUI extends JFrame
 
 			// solve user chords
 			String chords = userChords.getChordListString();
-			if (userChordsEnabled.isSelected() && !chords.contains("?")) {
+			if (userChordsEnabled.isSelected() && userChords.getChordletsRaw().size() > 0) {
 				Pair<List<String>, List<Double>> solvedChordsDurations = solveUserChords(chords,
 						userChordsDurations.getText());
 				if (solvedChordsDurations != null) {
@@ -6053,9 +6053,8 @@ public class VibeComposerGUI extends JFrame
 			sequencer.start();  // start the playback
 
 			loopBeatCount.getKnob()
-					.setMax(userChordsEnabled.isSelected()
-							? (int) Math.ceil(OMNI.sumListDouble(
-									OMNI.parseDoublesString(userChordsDurations.getText())))
+					.setMax(!MidiGenerator.userChordsDurations.isEmpty()
+							? (int) Math.ceil(OMNI.sumListDouble(MidiGenerator.userChordsDurations))
 							: MidiGenerator.chordInts.size() * 4);
 			startMidiCcThread();
 			recalculateTabPaneCounts();
@@ -9269,8 +9268,8 @@ public class VibeComposerGUI extends JFrame
 			return;
 		}
 		try {
-			// todo checkbox setting?
-			if (true) {
+			// todo checkbox setting - "transpose previewed note"
+			if (part < 4) {
 				Pair<ScaleMode, Integer> scaleKey = keyChangeAt(
 						actualArrangement.getSections().indexOf(sec));
 				List<Note> notes = Collections.singletonList(new Note(pitch, durationMs / 1000.0));

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -478,6 +478,7 @@ public class VibeComposerGUI extends JFrame
 	public static ScrollComboBox<String> melodyBlockTargetMode;
 	JCheckBox melodyTargetNotesRandomizeOnCompose;
 	ScrollComboBox<String> melodyPatternEffect;
+	ScrollComboBox<String> melodyRhythmAccents;
 	JCheckBox melodyPatternRandomizeOnCompose;
 	KnobPanel melodyReplaceAvoidNotes;
 	KnobPanel melodyMaxDirChanges;
@@ -1603,6 +1604,9 @@ public class VibeComposerGUI extends JFrame
 		melodyPatternEffect.setSelectedIndex(2);
 		melodyPatternRandomizeOnCompose = makeCheckBox(
 				"<html>Randomize Pattern<br> on Compose</html>", true, true);
+		melodyRhythmAccents = new ScrollComboBox<>(false);
+		ScrollComboBox.addAll(new String[] { "None", "Snares", "Kicks", "Rides,OpenHH",
+				"Snares,Kicks", "Snares,Rides,OpenHH" }, melodyRhythmAccents);
 
 		melodyReplaceAvoidNotes = new KnobPanel("Replace<br>Avoid Notes", 2, 0, 2);
 		melodyMaxDirChanges = new KnobPanel("Max. Dir.<br>Changes", 2, 1, 6);
@@ -1637,6 +1641,9 @@ public class VibeComposerGUI extends JFrame
 		melodySettingsExtraPanelBlocksPatternsCompose.add(new JLabel("Pattern Effect"));
 		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyPatternEffect);
 		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyPatternRandomizeOnCompose);
+		melodySettingsExtraPanelBlocksPatternsCompose
+				.add(new JLabel("<html>Drum Rhythm Accents<br>(Post-process)</html>"));
+		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyRhythmAccents);
 
 		JPanel melodySettingsExtraPanelOrg = new JPanel();
 		melodySettingsExtraPanelOrg.setBorder(BorderFactory.createBevelBorder(BevelBorder.RAISED));
@@ -7874,6 +7881,7 @@ public class VibeComposerGUI extends JFrame
 		gc.setMelodyAvoidChordJumps(melodyAvoidChordJumps.isSelected());
 		gc.setMelodyBlockTargetMode(melodyBlockTargetMode.getSelectedIndex());
 		gc.setMelodyPatternEffect(melodyPatternEffect.getSelectedIndex());
+		gc.setMelodyRhythmAccents(melodyRhythmAccents.getSelectedIndex());
 		gc.setMelodyReplaceAvoidNotes(melodyReplaceAvoidNotes.getInt());
 		gc.setMelodyMaxDirChanges(melodyMaxDirChanges.getInt());
 		gc.setMelodyTargetNoteVariation(melodyTargetNoteVariation.getInt());
@@ -8007,6 +8015,7 @@ public class VibeComposerGUI extends JFrame
 		melodyUseDirectionsFromProgression.setSelected(gc.isMelodyUseDirectionsFromProgression());
 		melodyBlockTargetMode.setSelectedIndex(gc.getMelodyBlockTargetMode());
 		melodyPatternEffect.setSelectedIndex(gc.getMelodyPatternEffect());
+		melodyRhythmAccents.setSelectedIndex(gc.getMelodyRhythmAccents());
 		melodyReplaceAvoidNotes.setInt(gc.getMelodyReplaceAvoidNotes());
 		melodyMaxDirChanges.setInt(gc.getMelodyMaxDirChanges());
 		melodyTargetNoteVariation.setInt(gc.getMelodyTargetNoteVariation());

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -830,10 +830,26 @@ public class VibeComposerGUI extends JFrame
 				@Override
 				public void mousePressed(MouseEvent e) {
 					int indx = instrumentTabPane.indexAtLocation(e.getX(), e.getY());
-					if (SwingUtilities.isRightMouseButton(e) && indx < 5 && indx >= 0) {
-						LG.i(("RMB pressed in instrument tab pane: " + indx));
-
-						setAddInst(indx, !addInst[indx].isSelected());
+					if (indx >= 0 && indx < 5) {
+						if (SwingUtilities.isRightMouseButton(e)) {
+							LG.i(("RMB pressed in instrument tab pane: " + indx));
+							setAddInst(indx, !addInst[indx].isSelected());
+						} else if (SwingUtilities.isMiddleMouseButton(e)) {
+							LG.i(("MMB pressed in instrument tab pane: " + indx));
+							boolean hasAny = false;
+							for (int i = 0; i < 5; i++) {
+								if (i != indx && addInst[i].isSelected()) {
+									hasAny = true;
+									break;
+								}
+							}
+							for (int i = 0; i < 5; i++) {
+								if (i != indx) {
+									setAddInst(i, !hasAny);
+								}
+							}
+							setAddInst(indx, true);
+						}
 					} else if (indx == 6) {
 						actualArrangement.getSections().forEach(s -> s.initPartMapFromOldData());
 						scrollableArrangementActualTable.repaint();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -555,6 +555,7 @@ public class VibeComposerGUI extends JFrame
 	JCheckBox arrangementScaleMidiVelocity;
 	public static KnobPanel humanizeNotes;
 	public static KnobPanel humanizeDrums;
+	public static KnobPanel globalNoteLengthMultiplier;
 	public static ScrollComboBox<Double> swingUnitMultiplier;
 	public static JCheckBox customMidiForceScale;
 	public static JCheckBox transposedNotesForceScale;
@@ -1177,6 +1178,10 @@ public class VibeComposerGUI extends JFrame
 		// / 10000
 		humanizeDrums = new DetachedKnobPanel("Humanize Drums<br>/10000", 20, 0, 100);
 
+		// / 1000
+		globalNoteLengthMultiplier = new DetachedKnobPanel("Note Length Multiplier<br>/1000", 950,
+				250, 1000);
+
 		swingUnitMultiplier = new ScrollComboBox<Double>(false);
 		ScrollComboBox.addAll(new Double[] { 0.5, 1.0, 2.0 }, swingUnitMultiplier);
 		swingUnitMultiplier.setSelectedIndex(0);
@@ -1188,6 +1193,7 @@ public class VibeComposerGUI extends JFrame
 
 		humanizationPanel.add(humanizeNotes);
 		humanizationPanel.add(humanizeDrums);
+		humanizationPanel.add(globalNoteLengthMultiplier);
 		humanizationPanel.add(new JLabel("Swing Period Multiplier"));
 		humanizationPanel.add(swingUnitMultiplier);
 		humanizationPanel.add(randomizeTimingsOnCompose);
@@ -5568,6 +5574,7 @@ public class VibeComposerGUI extends JFrame
 		try {
 			MidiGenerator.COLLAPSE_DRUM_TRACKS = combineDrumTracks.isSelected();
 			MidiGenerator.recalculateDurations(stretchMidi.getInt());
+			MidiGenerator.GLOBAL_DURATION_MULTIPLIER = globalNoteLengthMultiplier.getInt() / 1000.0;
 			MidiGenerator.RANDOMIZE_TARGET_NOTES = !regenerate
 					&& melodyTargetNotesRandomizeOnCompose.isSelected();
 			MidiGenerator.TARGET_NOTES = (melody1ForcePatterns.isSelected()
@@ -7654,6 +7661,9 @@ public class VibeComposerGUI extends JFrame
 
 		// drum panel
 		cs.add(randomDrumHitsMultiplierOnGenerate);
+
+		// extra settings
+		cs.add(globalNoteLengthMultiplier);
 
 		return cs;
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -1988,7 +1988,7 @@ public class VibeComposerGUI extends JFrame
 		randomChordExpandChance = new DetachedKnobPanel("Expand%", 70);
 		randomChordUseChordFill = new CustomCheckBox("Fills", true);
 		randomChordMaxSplitChance = new DetachedKnobPanel("Max Tran-<br>sition%", 25);
-		chordSlashChance = new KnobPanel("Chord1<br>Slash%", 30);
+		chordSlashChance = new KnobPanel("Chord1<br>Slash%", 5);
 		randomChordPattern = new CustomCheckBox("Patterns", true);
 		randomChordShiftChance = new DetachedKnobPanel("Shift%", 60);
 		randomChordMinVel = new DetachedKnobPanel("Min<br>Vel", 65, 0, 126);
@@ -5637,7 +5637,7 @@ public class VibeComposerGUI extends JFrame
 		try {
 			melodyGen.generateMasterpiece(masterpieceSeed, relPath);
 		} catch (Exception e) {
-			LG.e("Exception during midi generation! Cause: " + e.getMessage());
+			LG.e("Exception during midi generation! Cause: " + e.getMessage(), e);
 			composingInProgress = false;
 			new TemporaryInfoPopup(BUG_HUNT_MESSAGE, null);
 			reapplySolosMutes();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -1133,6 +1133,7 @@ public class VibeComposerGUI extends JFrame
 					recalculateTabPaneCounts();
 					recalculateGenerationCounts();
 					manualArrangement.setSelected(false);
+					midiMode.repaint();
 				} catch (JAXBException | IOException e) {
 					// TODO Auto-generated catch block
 					e.printStackTrace();
@@ -4167,6 +4168,7 @@ public class VibeComposerGUI extends JFrame
 		JButton randomizeCustomChords = makeButton("    Randomize Chords    ", e -> {
 			userChordsEnabled.setSelected(true);
 			randomizeUserChords();
+			userChordsEnabled.repaint();
 		});
 		customChordsPanel.add(randomizeCustomChords);
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -1660,7 +1660,7 @@ public class VibeComposerGUI extends JFrame
 			}
 		});
 		melodySettingsExtraPanelOrg.add(randomizeMelodies);
-		randomizeMelodiesOnCompose = makeCheckBox("On Compose", true, true);
+		randomizeMelodiesOnCompose = makeCheckBox("On Compose", false, true);
 		melodySettingsExtraPanelOrg.add(randomizeMelodiesOnCompose);
 
 		JButton generateUserMelodySeed = makeButton("Randomize Seed", e -> randomizeMelodySeeds());
@@ -1791,7 +1791,7 @@ public class VibeComposerGUI extends JFrame
 		for (int i = 0; i < 3; i++) {
 			MelodyPanel melodyPanel = new MelodyPanel(this);
 			((JPanel) melodyScrollPane.getViewport().getView()).add(melodyPanel);
-			melodyPanel.setInstrument(8);
+			melodyPanel.setInstrument(73);
 			melodyPanels.add(melodyPanel);
 			melodyPanel.setPanelOrder(i + 1);
 			if (i > 0) {
@@ -1818,13 +1818,13 @@ public class VibeComposerGUI extends JFrame
 				melodyPanel.getVolSlider().setValue(45);
 			} else {
 				melodyPanel.setFillPauses(false);
-				melodyPanel.setSpeed(25);
-				melodyPanel.setPauseChance(50);
+				melodyPanel.setSpeed(15);
+				melodyPanel.setPauseChance(15);
 				melodyPanel.setTranspose(12);
-				melodyPanel.setVelocityMax(105);
-				melodyPanel.setVelocityMin(45);
-				melodyPanel.getVolSlider().setValue(50);
-				melodyPanel.setNoteLengthMultiplier(115);
+				melodyPanel.setVelocityMax(100);
+				melodyPanel.setVelocityMin(50);
+				melodyPanel.getVolSlider().setValue(60);
+				melodyPanel.setNoteLengthMultiplier(108);
 			}
 		}
 
@@ -2239,7 +2239,7 @@ public class VibeComposerGUI extends JFrame
 		addInst[4] = new CustomCheckBox("DRUMS", true);
 		drumsPanel.add(addInst[4]);
 
-		drumVolumeSlider = new VeloRect(0, 100, 70);
+		drumVolumeSlider = new VeloRect(0, 100, 65);
 		//drumVolumeSlider.setOrientation(JSlider.VERTICAL);
 		drumVolumeSlider.setPreferredSize(new Dimension(15, 35));
 		//drumVolumeSlider.setPaintTicks(true);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -131,7 +131,6 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.TableColumnModelEvent;
 import javax.swing.event.TableColumnModelListener;
 import javax.swing.plaf.ColorUIResource;
-import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableModel;
 import javax.xml.bind.JAXBContext;
@@ -2956,9 +2955,12 @@ public class VibeComposerGUI extends JFrame
 				return comp;
 			}
 		};
-		TableModel model = new DefaultTableModel(7, 11);
 
-		scrollableArrangementTable.setModel(model);
+		arrangement = new Arrangement();
+		actualArrangement = new Arrangement();
+		arrangement.generateDefaultArrangement();
+
+		scrollableArrangementTable.setModel(arrangement.convertToTableModel());
 		arrangementScrollPane = new JScrollPane() {
 			@Override
 			public Dimension getPreferredSize() {
@@ -2977,10 +2979,6 @@ public class VibeComposerGUI extends JFrame
 		arrangementScrollPane.setRowHeaderView(list);
 		arrangementScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
 		arrangementScrollPane.getVerticalScrollBar().setUnitIncrement(16);
-
-		arrangement = new Arrangement();
-		actualArrangement = new Arrangement();
-		arrangement.generateDefaultArrangement();
 		//actualArrangement.generateDefaultArrangement();
 		if (useArrangement.isSelected()) {
 			arrangement.setPreviewChorus(false);
@@ -2990,7 +2988,6 @@ public class VibeComposerGUI extends JFrame
 			actualArrangement.setPreviewChorus(true);
 			actualArrangement.resetArrangement();
 		}
-		scrollableArrangementTable.setModel(arrangement.convertToTableModel());
 		scrollableArrangementTable.setRowSelectionAllowed(false);
 		scrollableArrangementTable.setColumnSelectionAllowed(true);
 		scrollableArrangementTable.getTableHeader().setPreferredSize(


### PR DESCRIPTION
Melody 
- 2 new variations: 
  - "Embellish" - changes some longer notes into a short riff of neighboring notes; 
  - "Solo" - increases repetitiveness of patterns and referencing to previous notes/riffs; snaps note end times closer to the grid
 -  Drum Rhythm Accents - new optional post-processing algorithm - melody will react to drums (e.g. cut the end of a long note when a snare hits, or change the note's pitch or volume at that moment)
 - % note targets - cleaner calculations, fewer notes straying too far away from tonal center
 
Score interactions
- mouse over any note to display note information - part, part #, note pitch (drum name in case of drums)
- LMB any note to open the corresponding MIDI section / piano roll
- MMB any note to solo this part only, MMB again to unsolo
- Shift+MMB any note to mute this part
- MMB parts buttons to view this part only or view all parts

Midi Editor / Piano roll
- persistent "helper" line near mouse cursor, time display
- Ctrl+LMB drag highlighted notes to create a copy
- Alt+RMB highlighted notes to split them at cursor location

Part Knobs/Settings
- Chord/Arp - new individual swing knobs
- Melody/Chord/Arp/Drum - Delays #, Feedback Duration, Feedback Volume - how many delay hits should happen, how far apart, and how much the volume should decrease (or increase) with each hit

General
- arrangement table - new colorization for parts based on part # and how many variations the subcell has
- combobox (all) - Ctrl+MMB to randomize selection in all parts
- combobox (pattern) - Shift+Ctrl+MMB to randomize a custom pattern for all parts
- velocity bars - scroll up or down to change value by +-5%
- knobs - scroll up or down to change value by +- 10% or change to next nearest value (for knobs with sticky pre-set values); CTRL while scrolling to apply new value to all parts
- global note length multiplier
- scrolling no longer blocked by comboboxes with scrolling disabled
- RMB or MMB a save/export button to open the corresponding save/export folder
- "Double Harmonic" scale
- Drum generation - selectable multiplier - multiplies the number of hits for each newly generated drum

[Bugfixes]