### PR TITLE
Feature 23 - Melody/Bass parts, Arp contour, New settings menu, QoL, Optimizations, Fixes

### DIFF
--- a/midimasterpiece/pom.xml
+++ b/midimasterpiece/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.vibehistorian.vibecomposer</groupId>
     <artifactId>vibecomposer</artifactId>
     <name>VibeComposer</name>
-    <version>v2.2-beta</version>
+    <version>v2.3-beta</version>
     <packaging>jar</packaging>
 
     <repositories>
@@ -129,12 +129,13 @@
                  </classPath>
                  <jre>
                    <minVersion>1.8.0</minVersion>
+                   <path>/</path>
                  </jre>
                  <versionInfo>
                    <fileVersion>1.1.1.1</fileVersion>
                    <txtFileVersion>1.1</txtFileVersion>
                    <fileDescription>VibeComposer</fileDescription>
-                   <copyright>Copyright VibeHistorian 2021</copyright>
+                   <copyright>Copyright VibeHistorian 2023</copyright>
                    <productVersion>1.1.1.1</productVersion>
                    <txtProductVersion>1.1</txtProductVersion>
                    <productName>VibeComposer</productName>
@@ -160,8 +161,6 @@
         </descriptorRefs>
         <finalName>${project.name}-${project.version}-JAR</finalName>
         <appendAssemblyId>false</appendAssemblyId>
-                <source>1.8</source>
-                <target>1.8</target>
       </configuration>
     </plugin>
   </plugins>

--- a/midimasterpiece/pom.xml
+++ b/midimasterpiece/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.vibehistorian.vibecomposer</groupId>
     <artifactId>vibecomposer</artifactId>
     <name>VibeComposer</name>
-    <version>v2.3-beta</version>
+    <version>2.3-beta</version>
     <packaging>jar</packaging>
 
     <repositories>

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Arrangement.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Arrangement.java
@@ -479,8 +479,10 @@ public class Arrangement {
 			}
 			partInclusionMap.put(i, data);
 		}
-		partInclusionMap.get(0)[0][1] = Boolean.FALSE;
-		partInclusionMap.get(0)[0][4] = Boolean.FALSE;
+		if (partInclusionMap.get(0).length > 0) {
+			partInclusionMap.get(0)[0][1] = Boolean.FALSE;
+			partInclusionMap.get(0)[0][4] = Boolean.FALSE;
+		}
 	}
 
 	public void initPartInclusionMapIfNull() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ArpPickerMini.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ArpPickerMini.java
@@ -158,7 +158,9 @@ public class ArpPickerMini extends ScrollComboPanel<ArpPattern> {
 			return;
 		}
 		instParent.getAllComponentsLike(this, ArpPickerMini.class).forEach(e -> {
-			e.setRandomCustomValues();
+			if (e.isEnabled()) {
+				e.setRandomCustomValues();
+			}
 		});
 	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/Chordlet.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/Chordlet.java
@@ -324,7 +324,7 @@ public class Chordlet extends JComponent {
 	}
 
 	public String getChordText() {
-		return getSpicedText() + (inversion != null ? ("." + inversion) : "");
+		return getSpicedText() + getInversionText();
 	}
 
 	public String getSpicedText() {
@@ -352,4 +352,7 @@ public class Chordlet extends JComponent {
 		update();
 	}
 
+	public String getInversionText() {
+		return (inversion != null ? ("." + inversion) : "");
+	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/CustomCheckBox.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/CustomCheckBox.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionListener;
 
 import javax.swing.Icon;
 import javax.swing.JCheckBox;
+import javax.swing.SwingConstants;
 
 import org.vibehistorian.vibecomposer.UndoManager;
 
@@ -30,6 +31,7 @@ public class CustomCheckBox extends JCheckBox {
 
 	public CustomCheckBox(String text, Icon icon, boolean selected) {
 		super(text, icon, selected);
+		this.setHorizontalTextPosition(SwingConstants.LEFT);
 		addActionListener(new ActionListener() {
 
 			@Override

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/InstComboBox.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/InstComboBox.java
@@ -22,10 +22,16 @@ public class InstComboBox extends ScrollComboBox<String> {
 	}
 
 	public void setInstPool(InstUtils.POOL instPool) {
+		if (!isEnabled()) {
+			return;
+		}
 		this.instPool = instPool;
 	}
 
 	public void initInstPool(InstUtils.POOL instPool) {
+		if (!isEnabled()) {
+			return;
+		}
 		this.instPool = instPool;
 		this.removeAllItems();
 		String[] choices = InstUtils.INST_POOLS.get(instPool);
@@ -49,6 +55,9 @@ public class InstComboBox extends ScrollComboBox<String> {
 	}
 
 	public void changeInstPoolMapping(String[] pool) {
+		if (!isEnabled()) {
+			return;
+		}
 		int index = getSelectedIndex();
 		this.removeAllItems();
 		for (String c : pool) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/JKnob.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/JKnob.java
@@ -3,6 +3,7 @@ package org.vibehistorian.vibecomposer.Components;
 
 // Imports for the GUI classes.
 import java.awt.Color;
+import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics;
@@ -94,6 +95,7 @@ public class JKnob extends JComponent
 	public static boolean fine = false;
 	public static int fineStart = 50;
 	public static boolean ctrlClick = false;
+	boolean scrollEnabled = true;
 
 	private Consumer<? super Object> func = null;
 
@@ -161,6 +163,12 @@ public class JKnob extends JComponent
 
 			@Override
 			public void mouseWheelMoved(MouseWheelEvent e) {
+				if (!scrollEnabled && !e.isControlDown()) {
+					Container cont = JKnob.this.getParent();
+					cont.dispatchEvent(SwingUtilities.convertMouseEvent(e.getComponent(), e, cont));
+					return;
+				}
+
 				int val = 0;
 				if (tickSpacing > 0) {
 					int index = tickThresholds.indexOf(curr);
@@ -820,5 +828,13 @@ public class JKnob extends JComponent
 
 	public int getValueRaw() {
 		return curr;
+	}
+
+	public boolean isScrollEnabled() {
+		return scrollEnabled;
+	}
+
+	public void setScrollEnabled(boolean scrollEnabled) {
+		this.scrollEnabled = scrollEnabled;
 	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/JKnob.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/JKnob.java
@@ -793,8 +793,10 @@ public class JKnob extends JComponent
 		}
 		for (InstPanel ip : VibeComposerGUI.getAffectedPanels(instParent.getPartNum())) {
 			ip.findKnobsByName(getName()).forEach(e -> {
-				e.setValue(val);
-				e.paintComponent(e.getGraphics());
+				if (e.isEnabled()) {
+					e.setValue(val);
+					e.paintComponent(e.getGraphics());
+				}
 			});
 		}
 	}
@@ -808,8 +810,10 @@ public class JKnob extends JComponent
 		}
 		for (InstPanel ip : VibeComposerGUI.getAffectedPanels(instParent.getPartNum())) {
 			ip.findKnobsByName(getName()).forEach(e -> {
-				e.setTheta(thetaVal);
-				e.paintComponent(e.getGraphics());
+				if (e.isEnabled()) {
+					e.setTheta(thetaVal);
+					e.paintComponent(e.getGraphics());
+				}
 			});
 		}
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
@@ -232,8 +232,7 @@ public class MidiEditArea extends JComponent {
 		} else if (evt.isControlDown()) {
 			if (orderVal != null && values.get(orderVal.x).getPitch() >= 0) {
 				PhraseNote note = values.get(orderVal.x);
-				int velocity = OMNI.clamp((int) (127 * (orderVal.y - min) / (double) (max - min)),
-						0, 127);
+				int velocity = OMNI.clampVel((127 * (orderVal.y - min) / (double) (max - min)));
 				if (velocity != note.getDynamic()) {
 					note.setDynamic(velocity);
 					playNote(note);
@@ -574,8 +573,8 @@ public class MidiEditArea extends JComponent {
 					Point orderVal = getOrderAndValueFromPosition(evt.getPoint());
 					if (orderVal != null && values.get(orderVal.x).getPitch() >= 0) {
 						PhraseNote note = values.get(orderVal.x);
-						int velocity = OMNI.clamp(
-								(int) (127 * (orderVal.y - min) / (double) (max - min)), 0, 127);
+						int velocity = OMNI
+								.clampVel((127 * (orderVal.y - min) / (double) (max - min)));
 						if (velocity != note.getDynamic()) {
 							note.setDynamic(velocity);
 							playNote(note);
@@ -661,7 +660,7 @@ public class MidiEditArea extends JComponent {
 				// VELOCITY
 				if (draggingAny(DM.VELOCITY)) {
 					int velocity = getVelocityFromPosition(evt.getPoint());
-					velocity = OMNI.clamp(velocity, 0, 127);
+					velocity = OMNI.clampVel(velocity);
 					if (draggingAny(DM.MULTIPLE)) {
 						int velocityChange = velocity - draggedNoteCopy.getDynamic();
 						for (int i = 0; i < selectedNotesCopy.size(); i++) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
@@ -1241,7 +1241,7 @@ public class MidiEditArea extends JComponent {
 		double quarterNoteLength = getQuarterNoteLength();
 
 		double durationTime = (xy.x - marginX) / quarterNoteLength;
-		double mouseCorrectionTime = (dragX - marginX - startTime) / quarterNoteLength;
+		double mouseCorrectionTime = (dragX - marginX) / quarterNoteLength;
 
 		return draggedNoteCopy.getDuration() + durationTime - mouseCorrectionTime;
 	}
@@ -1255,7 +1255,7 @@ public class MidiEditArea extends JComponent {
 		double quarterNoteLength = getQuarterNoteLength();
 
 		double offsetTime = (xy.x - marginX) / quarterNoteLength;
-		double mouseCorrectionTime = (dragX - marginX - startTime) / quarterNoteLength;
+		double mouseCorrectionTime = (dragX - marginX) / quarterNoteLength;
 
 		return draggedNoteCopy.getOffset() + offsetTime - mouseCorrectionTime;
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
@@ -660,11 +660,11 @@ public class MidiEditArea extends JComponent {
 				// VELOCITY
 				if (draggingAny(DM.VELOCITY)) {
 					int velocity = getVelocityFromPosition(evt.getPoint());
-					velocity = OMNI.clampVel(velocity);
+					velocity = OMNI.clampMidi(velocity);
 					if (draggingAny(DM.MULTIPLE)) {
 						int velocityChange = velocity - draggedNoteCopy.getDynamic();
 						for (int i = 0; i < selectedNotesCopy.size(); i++) {
-							selectedNotes.get(i).setDynamic(OMNI.clampVel(
+							selectedNotes.get(i).setDynamic(OMNI.clampMidi(
 									selectedNotesCopy.get(i).getDynamic() + velocityChange));
 						}
 					} else {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
@@ -908,7 +908,8 @@ public class MidiEditArea extends JComponent {
 
 
 			// draw chord spacing
-			if ((pop != null) && (pop.getSec() != null)) {
+			if ((pop != null) && (pop.getSec() != null)
+					&& (pop.getSec().getGeneratedDurations() != null)) {
 				List<Double> chordSpacings = new ArrayList<>(pop.getSec().getGeneratedDurations());
 				double spacingSum = chordSpacings.stream().mapToDouble(e -> e).sum()
 						* pop.getSec().getMeasures();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
@@ -1153,7 +1153,7 @@ public class MidiEditArea extends JComponent {
 			return null;
 		}
 
-		if (sec == null || !sec.isCustomChordsDurationsEnabled()) {
+		if (sec == null || !sec.isCustomChordsEnabled()) {
 			return MidiUtils.getHighlightTargetsFromChords(MidiGenerator.chordInts, false);
 		} else {
 			return MidiUtils.getHighlightTargetsFromChords(sec.getCustomChordsList(), false);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiEditArea.java
@@ -98,15 +98,22 @@ public class MidiEditArea extends JComponent {
 						setAndRepaint();
 					}
 				} else {
-					int rot = (e.getWheelRotation() > 0) ? -1 : 1;
+					int rot = (e.getWheelRotation() > 0) ? 1 : -1;
 					int originalTrackScope = MidiEditPopup.trackScope;
 					if (rot > 0 && (max > 120 || min < 10)) {
 						return;
 					}
-					MidiEditPopup.trackScope = Math.max(originalTrackScope + rot, 1);
+					MidiEditPopup.trackScope = originalTrackScope + rot;
+					if (rot < 0 && ((max - min) <= MidiEditPopup.baseMargin * 4)) {
+						MidiEditPopup.trackScope++;
+					}
 					if (originalTrackScope != MidiEditPopup.trackScope) {
-						min -= MidiEditPopup.baseMargin * rot;
-						max += MidiEditPopup.baseMargin * rot;
+						if (!(rot > 0 && max > 120)) {
+							max += MidiEditPopup.baseMargin * rot;
+						}
+						if (!(rot > 0 && min < 10)) {
+							min -= MidiEditPopup.baseMargin * rot;
+						}
 						setAndRepaint();
 					}
 				}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiMVI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiMVI.java
@@ -11,8 +11,10 @@ import java.util.Set;
 import javax.swing.JComponent;
 import javax.swing.SwingUtilities;
 
+import org.apache.commons.lang3.StringUtils;
 import org.vibehistorian.vibecomposer.LG;
 import org.vibehistorian.vibecomposer.OMNI;
+import org.vibehistorian.vibecomposer.Section;
 import org.vibehistorian.vibecomposer.SwingUtils;
 import org.vibehistorian.vibecomposer.VibeComposerGUI;
 import org.vibehistorian.vibecomposer.Helpers.PhraseNotes;
@@ -134,7 +136,8 @@ public class MidiMVI extends JComponent {
 		if (VibeComposerGUI.guiConfig.getPatternMaps().isEmpty()) {
 			return false;
 		}
-
+		int partNum = parent.getPartNum();
+		int panelOrder = parent.getPanelOrder();
 		if (i <= 2) {
 			PhraseNotes pn = VibeComposerGUI.guiConfig.getPatternRaw(parent.getPartNum(),
 					parent.getPanelOrder(), UsedPattern.BASE_PATTERNS[i + 1]);
@@ -148,14 +151,32 @@ public class MidiMVI extends JComponent {
 			for (String bp : UsedPattern.BASE_PATTERNS) {
 				patternNames.remove(bp);
 			}
-			for (String name : patternNames) {
+
+			// remove not applied patterns
+			patternNames.removeIf(name -> {
 				PhraseNotes pn = VibeComposerGUI.guiConfig.getPatternRaw(parent.getPartNum(),
 						parent.getPanelOrder(), name);
-				if (pn != null && pn.isApplied()) {
-					return true;
-				}
+				return (pn == null || !pn.isApplied());
+			});
 
+			// pattern name must appear in at least one section
+			for (int secIndex = 0; secIndex < VibeComposerGUI.actualArrangement.getSections()
+					.size(); secIndex++) {
+				Section sec = VibeComposerGUI.actualArrangement.getSections().get(secIndex);
+				if (sec.containsPattern(partNum, panelOrder)) {
+					String secPatternName = sec.getPattern(partNum, panelOrder).getName();
+					if (StringUtils.isNotEmpty(secPatternName)) {
+						for (String name : patternNames) {
+							if (secPatternName.equals(name)) {
+								return true;
+							}
+
+						}
+					}
+				}
 			}
+
+
 			return false;
 		}
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiMVI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/MidiMVI.java
@@ -25,8 +25,11 @@ public class MidiMVI extends JComponent {
 	private static final long serialVersionUID = 2226722368743495710L;
 
 	public static final String[] BUTTONS = { "M", "V", "I", "C" };
+	public static final int BUTTON_ROWS = 2;
 	public static final int BUTTON_WIDTH = 15;
-	public static final Dimension DEFAULT_SIZE = new Dimension(BUTTON_WIDTH * BUTTONS.length, 25);
+	public static final int BUTTON_HEIGHT = 18;
+	public static final Dimension DEFAULT_SIZE = new Dimension(
+			BUTTON_WIDTH * ((BUTTONS.length + 1) / 2), BUTTON_HEIGHT * BUTTON_ROWS);
 	Dimension defaultSize = DEFAULT_SIZE;
 	InstPanel parent;
 
@@ -90,18 +93,36 @@ public class MidiMVI extends JComponent {
 			int width = getWidth();
 			int height = getHeight();
 			g.fillRect(0, 0, width, height);
+			int buttonMaxPerRow = (BUTTONS.length + 1) / 2;
 
-			for (int i = 0; i < BUTTONS.length; i++) {
+			for (int i = 0; i < buttonMaxPerRow; i++) {
 				boolean active = isActive(i);
-				g.setColor(OMNI.alphen(CollectionCellRenderer.CUSTOM_PATTERN_COLORS[i],
+				g.setColor(OMNI.alphen(
+						CollectionCellRenderer.CUSTOM_PATTERN_COLORS[i
+								% CollectionCellRenderer.CUSTOM_PATTERN_COLORS.length],
 						active ? 190 : 50));
 				int startX = i * BUTTON_WIDTH + 1;
 
-				g.fillRect(startX, 0, BUTTON_WIDTH, height);
+				g.fillRect(startX, 0, BUTTON_WIDTH, BUTTON_HEIGHT);
 				g.setColor(Color.white);
 				g.drawString(BUTTONS[i],
 						startX + BUTTON_WIDTH / 2 - SwingUtils.getDrawStringWidth(BUTTONS[i]) / 2,
-						height * 2 / 3);
+						height * 1 / 3);
+			}
+
+			for (int i = buttonMaxPerRow; i < BUTTONS.length; i++) {
+				boolean active = isActive(i);
+				g.setColor(OMNI.alphen(
+						CollectionCellRenderer.CUSTOM_PATTERN_COLORS[i
+								% CollectionCellRenderer.CUSTOM_PATTERN_COLORS.length],
+						active ? 190 : 50));
+				int startX = (i - buttonMaxPerRow) * BUTTON_WIDTH + 1;
+
+				g.fillRect(startX, BUTTON_HEIGHT + 1, BUTTON_WIDTH, height);
+				g.setColor(Color.white);
+				g.drawString(BUTTONS[i],
+						startX + BUTTON_WIDTH / 2 - SwingUtils.getDrawStringWidth(BUTTONS[i]) / 2,
+						height * 5 / 6);
 			}
 
 			g.setColor(Color.black);
@@ -144,7 +165,16 @@ public class MidiMVI extends JComponent {
 			return -1;
 		}
 
-		return OMNI.clamp(evt.getPoint().x / BUTTON_WIDTH, 0, BUTTONS.length - 1);
+		if (BUTTONS.length == 1) {
+			return 0;
+		}
+
+		int maxButtonsPerRow = (BUTTONS.length + 1) / 2;
+		int xButton = OMNI.clamp(evt.getPoint().x / BUTTON_WIDTH, 0, maxButtonsPerRow - 1);
+		int yButton = OMNI.clamp(evt.getPoint().y / BUTTON_HEIGHT, 0, BUTTON_ROWS - 1);
+		int buttonOrder = xButton + yButton * maxButtonsPerRow;
+
+		return buttonOrder < BUTTONS.length ? buttonOrder : -1;
 	}
 
 	public void updateSizes(Dimension size) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/RandomIntegerListButton.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/RandomIntegerListButton.java
@@ -4,6 +4,7 @@ import java.awt.Dimension;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -68,6 +69,9 @@ public class RandomIntegerListButton extends JButton {
 	}
 
 	public List<Integer> getValues() {
+		if (getValue().isEmpty()) {
+			return new ArrayList<>(Arrays.asList(new Integer[] { 0 }));
+		}
 		String[] valueSplit = getValue().split(",");
 		List<Integer> values = new ArrayList<>();
 		for (String s : valueSplit) {
@@ -78,20 +82,23 @@ public class RandomIntegerListButton extends JButton {
 	}
 
 	public String getValue() {
-		return getText();
+		String txt = getText();
+		return "?".equals(txt) ? "" : txt;
 	}
 
 	public void setValues(List<Integer> values) {
-		setValue(StringUtils.join(values, ","));
+		setValue((values != null) ? StringUtils.join(values, ",") : "?");
 	}
 
 	public void setValue(String value) {
 		if (!isEnabled()) {
 			return;
 		}
+		if (StringUtils.isEmpty(value)) {
+			value = "?";
+		}
 		setText(value);
-
-		if (postFunc != null) {
+		if (!"?".equals(value) && (postFunc != null)) {
 			postFunc.accept(new Object());
 		}
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ScrollComboPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ScrollComboPanel.java
@@ -146,8 +146,10 @@ public class ScrollComboPanel<T> extends TransparentablePanel implements Globall
 			return;
 		}
 		instParent.getAllComponentsLike(this, ScrollComboPanel.class).forEach(e -> {
-			e.selectRandomValue();
-			e.repaint();
+			if (e.isEnabled()) {
+				e.selectRandomValue();
+				e.repaint();
+			}
 		});
 	}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/SectionInfoCellRenderer.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/SectionInfoCellRenderer.java
@@ -54,10 +54,10 @@ public class SectionInfoCellRenderer extends JComponent implements TableCellRend
 				g.setColor(new Color(230, 230, 230));
 				g.drawString("" + sec.getMeasures(), 3, height / 2);
 
-				String customDurations = sec.isCustomChordsDurationsEnabled()
+				String customDurations = sec.isCustomChordsEnabled()
 						? sec.getCustomDurations().replaceAll(" ", "")
 						: "";
-				String customChords = ((sec.isCustomChordsDurationsEnabled()
+				String customChords = ((sec.isCustomChordsEnabled()
 						|| sec.isDisplayAlternateChords())
 								? sec.getCustomChords().replaceAll(" ", "")
 								: "");
@@ -65,7 +65,7 @@ public class SectionInfoCellRenderer extends JComponent implements TableCellRend
 						? VibeComposerGUI.userChords.getChordListString()
 						: StringUtils.join(MidiGenerator.chordInts, ",")).replaceAll(" ", "");
 
-				String guiUserDurations = (VibeComposerGUI.userChordsEnabled.isSelected()
+				String guiUserDurations = (VibeComposerGUI.userDurationsEnabled.isSelected()
 						? VibeComposerGUI.userChordsDurations.getText()
 						: "4,4,4,4").replaceAll(" ", "");
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/SectionInfoCellRenderer.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/SectionInfoCellRenderer.java
@@ -54,7 +54,7 @@ public class SectionInfoCellRenderer extends JComponent implements TableCellRend
 				g.setColor(new Color(230, 230, 230));
 				g.drawString("" + sec.getMeasures(), 3, height / 2);
 
-				String customDurations = sec.isCustomChordsEnabled()
+				String customDurations = sec.isCustomDurationsEnabled()
 						? sec.getCustomDurations().replaceAll(" ", "")
 						: "";
 				String customChords = ((sec.isCustomChordsEnabled()

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowAreaBig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowAreaBig.java
@@ -297,6 +297,10 @@ public class ShowAreaBig extends JComponent {
 	 * @param int The new note height
 	 */
 	public void setNoteHeight(int val) {
+		if (val < 4) {
+			repaint();
+			return;
+		}
 		noteHeight = val;
 		reInit();
 		repaint();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowPanelBig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowPanelBig.java
@@ -70,10 +70,13 @@ public class ShowPanelBig extends JPanel {
 	private static final long serialVersionUID = 1464206032589622048L;
 	public Score score;
 	protected double beatWidth; //10.0;
-	public static final int beatWidthBaseDefault = 1500;
-	public static int beatWidthBase = 1550;
-	public static final List<Integer> beatWidthBases = Arrays.asList(new Integer[] { 1550, 1800,
+	public static final int beatWidthBaseDefault = 1600;
+	public static int beatWidthBase = 1600;
+	public static final List<Integer> beatWidthBasesBig = Arrays.asList(new Integer[] { 1600, 1800,
 			2200, 2700, 3300, 4000, 4800, 5700, 6800, 8200, 10000, 12500 });
+	public static final List<Integer> beatWidthBasesSmall = Arrays.asList(
+			new Integer[] { 630, 800, 1050, 1300, 1550, 1800, 2200, 2700, 3300, 4000, 4800, 5700 });
+	public static List<Integer> beatWidthBases = beatWidthBasesBig;
 	public static int beatWidthBaseIndex = 0;
 	public static int panelMaxHeight = VibeComposerGUI.scrollPaneDimension.height;
 	private ShowAreaBig sa;
@@ -81,7 +84,7 @@ public class ShowPanelBig extends JPanel {
 	private JPanel pan;
 	private int panelHeight;
 	public static JScrollPane areaScrollPane;
-	private JScrollPane rulerScrollPane;
+	public static JScrollPane rulerScrollPane;
 	public static JScrollPane horizontalPane;
 	public static CheckButton soloMuterHighlight;
 	public static double maxEndTime = 10.0;
@@ -125,12 +128,12 @@ public class ShowPanelBig extends JPanel {
 		horizontalPane = new JScrollPane() {
 			@Override
 			public Dimension getPreferredSize() {
-				return new Dimension(beatWidthBase - 50, getHeight() - 50);
+				return new Dimension(beatWidthBases.get(0), getHeight() - 50);
 			}
 
 			@Override
 			public Dimension getMinimumSize() {
-				return new Dimension(beatWidthBase - 50, getHeight() - 50);
+				return new Dimension(beatWidthBases.get(0), getHeight() - 50);
 			}
 		};
 		horizontalPane.setViewportView(pan);
@@ -326,6 +329,7 @@ public class ShowPanelBig extends JPanel {
 			}
 		};
 		rulerScrollPane.setViewportView(rulerPanel);
+		// for parity with area
 		rulerScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
 		rulerScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
 		rulerScrollPane.getVerticalScrollBar().setUnitIncrement(16);
@@ -525,11 +529,12 @@ public class ShowPanelBig extends JPanel {
 				.round((ShowAreaBig.noteOffsetXMargin + ShowPanelBig.maxEndTime) * beatWidth);
 		sa.setSize(sizeX, panelHeight);
 		ruler.setSize(sizeX, ShowRulerBig.maxHeight);
-		//areaScrollPane.setSize(sizeX, panelHeight - 70);
-		//horizontalPane.setSize(sizeX - 50, panelHeight);
-		//rulerScrollPane.setSize(sizeX, ShowRulerBig.maxHeight + 10);
 		pan.repaint();
 		repaintMinimum();
+		areaScrollPane.setMaximumSize(new Dimension(beatWidthBase, panelHeight - 70));
+		rulerScrollPane.setMaximumSize(new Dimension(beatWidthBase, ShowRulerBig.maxHeight + 10));
+		horizontalPane.setMaximumSize(new Dimension(beatWidthBases.get(0), panelHeight - 30));
+		horizontalPane.setSize(new Dimension(beatWidthBases.get(0), panelHeight - 30));
 		this.repaint();
 	}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowPanelBig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/ShowPanelBig.java
@@ -100,7 +100,7 @@ public class ShowPanelBig extends JPanel {
 		super();
 
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-
+		setAlignmentX(LEFT_ALIGNMENT);
 		// Because the ScrollPanel can only take one componenet 
 		// a panel called apn is created to hold all comoponenets
 		// then only pan is added to this classes ScrollPane
@@ -125,13 +125,19 @@ public class ShowPanelBig extends JPanel {
 		horizontalPane = new JScrollPane() {
 			@Override
 			public Dimension getPreferredSize() {
-				return new Dimension(beatWidthBaseDefault, getHeight() - 50);
+				return new Dimension(beatWidthBase - 50, getHeight() - 50);
+			}
+
+			@Override
+			public Dimension getMinimumSize() {
+				return new Dimension(beatWidthBase - 50, getHeight() - 50);
 			}
 		};
 		horizontalPane.setViewportView(pan);
 		horizontalPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS);
 		horizontalPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
 		horizontalPane.getHorizontalScrollBar().setUnitIncrement(16);
+		horizontalPane.setAlignmentX(LEFT_ALIGNMENT);
 
 
 		scorePartPanel = new JPanel();
@@ -278,10 +284,12 @@ public class ShowPanelBig extends JPanel {
 		};
 
 		sa.addMouseListener(ml);
+		sa.setAlignmentX(LEFT_ALIGNMENT);
 
 		JPanel areaPanel = new JPanel();
 		areaPanel.setMaximumSize(new Dimension(beatWidthBases.get(beatWidthBases.size() - 1),
 				ShowAreaBig.areaHeight));
+		areaPanel.setAlignmentX(LEFT_ALIGNMENT);
 		areaPanel.add(sa);
 
 		areaScrollPane = new JScrollPane() {
@@ -294,6 +302,7 @@ public class ShowPanelBig extends JPanel {
 		areaScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
 		areaScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
 		areaScrollPane.getVerticalScrollBar().setUnitIncrement(16);
+		areaScrollPane.setAlignmentX(LEFT_ALIGNMENT);
 		setupMouseWheelListener();
 
 		areaPanel.setVisible(true);
@@ -302,10 +311,12 @@ public class ShowPanelBig extends JPanel {
 		ruler = new ShowRulerBig(this);
 		ruler.setVisible(true);
 		ruler.addMouseListener(ml);
+		ruler.setAlignmentX(LEFT_ALIGNMENT);
 
 		JPanel rulerPanel = new JPanel();
 		rulerPanel.setMaximumSize(new Dimension(beatWidthBases.get(beatWidthBases.size() - 1),
 				ShowRulerBig.maxHeight));
+		rulerPanel.setAlignmentX(LEFT_ALIGNMENT);
 		rulerPanel.add(ruler);
 
 		rulerScrollPane = new JScrollPane() {
@@ -318,6 +329,7 @@ public class ShowPanelBig extends JPanel {
 		rulerScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
 		rulerScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
 		rulerScrollPane.getVerticalScrollBar().setUnitIncrement(16);
+		rulerScrollPane.setAlignmentX(LEFT_ALIGNMENT);
 
 
 		rulerPanel.setVisible(true);
@@ -483,7 +495,7 @@ public class ShowPanelBig extends JPanel {
 		update();
 		//LG.d();
 		//areaScrollPane.getVerticalScrollBar().setValue(50);
-		repaint();
+		//repaint();
 	}
 
 	/**
@@ -491,7 +503,7 @@ public class ShowPanelBig extends JPanel {
 	 */
 	public void updatePanelHeight(int height) {
 		panelHeight = height;
-		this.setSize(new Dimension(beatWidthBaseDefault, panelHeight));
+		this.setSize(new Dimension(beatWidthBase - 50, panelHeight));
 	}
 
 	/**
@@ -513,6 +525,9 @@ public class ShowPanelBig extends JPanel {
 				.round((ShowAreaBig.noteOffsetXMargin + ShowPanelBig.maxEndTime) * beatWidth);
 		sa.setSize(sizeX, panelHeight);
 		ruler.setSize(sizeX, ShowRulerBig.maxHeight);
+		//areaScrollPane.setSize(sizeX, panelHeight - 70);
+		//horizontalPane.setSize(sizeX - 50, panelHeight);
+		//rulerScrollPane.setSize(sizeX, ShowRulerBig.maxHeight + 10);
 		pan.repaint();
 		repaintMinimum();
 		this.repaint();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/VeloRect.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Components/VeloRect.java
@@ -53,6 +53,9 @@ public class VeloRect extends JComponent {
 			@Override
 			public void mousePressed(MouseEvent evt) {
 				if (!isEnabled()) {
+					if ((visualParent != null) && SwingUtilities.isLeftMouseButton(evt)) {
+						visualParent.checkPattern(visualParentOrderIndex, 1);
+					}
 					return;
 				}
 				if (SwingUtilities.isLeftMouseButton(evt)) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
@@ -127,9 +127,9 @@ public class GUIConfig {
 
 	private boolean useChordFormula = false;
 	private int longProgressionSimilarity = 0;
-	private boolean customChordsEnabled = true;
-	private boolean customDurationsEnabled = true;
-	private String customChords = "?";
+	private boolean customChordsEnabled = false;
+	private boolean customDurationsEnabled = false;
+	private String customChords = "C";
 	private String customChordDurations = "4,4,4,4";
 
 	// arp gen

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
@@ -128,6 +128,7 @@ public class GUIConfig {
 	private boolean useChordFormula = false;
 	private int longProgressionSimilarity = 0;
 	private boolean customChordsEnabled = true;
+	private boolean customDurationsEnabled = true;
 	private String customChords = "?";
 	private String customChordDurations = "4,4,4,4";
 
@@ -899,6 +900,14 @@ public class GUIConfig {
 			return null;
 		}
 		return patternMaps.get(part).getRaw(partOrder, patName);
+	}
+
+	public boolean isCustomDurationsEnabled() {
+		return customDurationsEnabled;
+	}
+
+	public void setCustomDurationsEnabled(boolean customDurationsEnabled) {
+		this.customDurationsEnabled = customDurationsEnabled;
 	}
 
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
@@ -101,6 +101,7 @@ public class GUIConfig {
 	private boolean melodyArpySurprises = false;
 	private boolean melodySingleNoteExceptions = false;
 	private boolean melodyFillPausesPerChord = false;
+	private int melodyNewBlocksChance = 0;
 	private boolean melodyLegacyMode = false;
 
 	private boolean melodyAvoidChordJumps = false;
@@ -917,6 +918,14 @@ public class GUIConfig {
 
 	public void setRandomArpCorrectMelodyNotes(boolean randomArpCorrectMelodyNotes) {
 		this.randomArpCorrectMelodyNotes = randomArpCorrectMelodyNotes;
+	}
+
+	public int getMelodyNewBlocksChance() {
+		return melodyNewBlocksChance;
+	}
+
+	public void setMelodyNewBlocksChance(int melodyNewBlocksChance) {
+		this.melodyNewBlocksChance = melodyNewBlocksChance;
 	}
 
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
@@ -134,6 +134,7 @@ public class GUIConfig {
 
 	// arp gen
 	private boolean useOctaveAdjustments = false;
+	private boolean randomArpCorrectMelodyNotes = false;
 
 	// drum gen
 	private boolean drumCustomMapping = true;
@@ -908,6 +909,14 @@ public class GUIConfig {
 
 	public void setCustomDurationsEnabled(boolean customDurationsEnabled) {
 		this.customDurationsEnabled = customDurationsEnabled;
+	}
+
+	public boolean isRandomArpCorrectMelodyNotes() {
+		return randomArpCorrectMelodyNotes;
+	}
+
+	public void setRandomArpCorrectMelodyNotes(boolean randomArpCorrectMelodyNotes) {
+		this.randomArpCorrectMelodyNotes = randomArpCorrectMelodyNotes;
 	}
 
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
@@ -108,6 +108,7 @@ public class GUIConfig {
 	private boolean melodyPatternFlip = false;
 	private int melodyBlockTargetMode = 2;
 	private int melodyPatternEffect = 2;
+	private boolean melodyPatternFlexible = false;
 	private int melodyRhythmAccents = 0;
 	private int melodyRhythmAccentsMode = 0;
 	private boolean melodyRhythmAccentsPocket = false;
@@ -899,6 +900,14 @@ public class GUIConfig {
 			return null;
 		}
 		return patternMaps.get(part).getRaw(partOrder, patName);
+	}
+
+	public boolean isMelodyPatternFlexible() {
+		return melodyPatternFlexible;
+	}
+
+	public void setMelodyPatternFlexible(boolean melodyPatternFlexible) {
+		this.melodyPatternFlexible = melodyPatternFlexible;
 	}
 
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/GUIConfig.java
@@ -108,7 +108,6 @@ public class GUIConfig {
 	private boolean melodyPatternFlip = false;
 	private int melodyBlockTargetMode = 2;
 	private int melodyPatternEffect = 2;
-	private boolean melodyPatternFlexible = false;
 	private int melodyRhythmAccents = 0;
 	private int melodyRhythmAccentsMode = 0;
 	private boolean melodyRhythmAccentsPocket = false;
@@ -900,14 +899,6 @@ public class GUIConfig {
 			return null;
 		}
 		return patternMaps.get(part).getRaw(partOrder, patName);
-	}
-
-	public boolean isMelodyPatternFlexible() {
-		return melodyPatternFlexible;
-	}
-
-	public void setMelodyPatternFlexible(boolean melodyPatternFlexible) {
-		this.melodyPatternFlexible = melodyPatternFlexible;
 	}
 
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Helpers/CheckBoxIcon.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Helpers/CheckBoxIcon.java
@@ -7,6 +7,7 @@ import java.awt.Graphics;
 import javax.swing.AbstractButton;
 import javax.swing.ButtonModel;
 import javax.swing.Icon;
+import javax.swing.SwingConstants;
 
 import org.vibehistorian.vibecomposer.VibeComposerGUI;
 
@@ -27,9 +28,15 @@ public class CheckBoxIcon implements Icon {
 						: VibeComposerGUI.panelColorHigh);
 		g.setColor(color);
 
-		g.drawRect(1, 1, width, height);
-		g.fillRect(3, 3, width - 2, height - 2);
-
+		int newHeight = (abstractButton.getHeight() - height) / 2;
+		if (abstractButton.getHorizontalTextPosition() == SwingConstants.LEFT) {
+			int newWidth = abstractButton.getWidth() - width;
+			g.drawRect(newWidth - 3, newHeight, width, height);
+			g.fillRect(newWidth - 1, newHeight + 2, width - 2, height - 2);
+		} else {
+			g.drawRect(1, newHeight, width, height);
+			g.fillRect(3, newHeight + 2, width - 2, height - 2);
+		}
 	}
 
 	@Override

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.vibehistorian.vibecomposer.MidiGenerator.Durations;
+import org.vibehistorian.vibecomposer.Popups.TemporaryInfoPopup;
 
 import jm.music.data.Note;
 
@@ -220,6 +221,11 @@ public class MelodyUtils {
 			LG.d("Viable blocks size is 0, getting random block!");
 			Integer[] block = getRandomForTypeAndBlockChangeAndLength(null, blockChange, length,
 					melodyBlockGenerator, 4);
+			if (block == null) {
+				LG.e("**************************************Fatal error generating melody block!");
+				new TemporaryInfoPopup(
+						"Error generating melody block: " + blockChange + ", " + length, 2000);
+			}
 			return Pair.of(blockOfList(block), block);
 		}
 		return viableBlocks.get(melodyBlockGenerator.nextInt(viableBlocks.size()));

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
@@ -33,10 +33,12 @@ public class MelodyUtils {
 	public static Map<Integer, Set<Integer>> AVAILABLE_BLOCK_CHANGES_PER_TYPE = new HashMap<>();
 	public static List<List<Integer>> MELODY_PATTERNS = new ArrayList<>();
 	public static List<List<Integer>> SOLO_MELODY_PATTERNS = new ArrayList<>();
+	public static List<Integer> ALT_PATTERN_INDEXES = new ArrayList<>(
+			Arrays.asList(new Integer[] { 0, 1, 8, 9, 10, 12, 15, 16 }));
 
 	public static List<List<Integer>> CHORD_DIRECTIONS = new ArrayList<>();
 
-	public static final int NUM_LISTS = 3;
+	public static final int NUM_LISTS = 4;
 
 	static {
 
@@ -57,6 +59,7 @@ public class MelodyUtils {
 		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 2, 0, 1, 2 }));
 		CHORD_DIRECTIONS.add(Arrays.asList(new Integer[] { 2, 0, -1, 1 }));
 
+		// ALT PATTERNS: 0, 1, 8, 9, 10, 12, 15, 16
 		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 2, 1, 3 }));
 		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 2, 1, 3, 1, 2, 1, 4 }));
 		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 1, 2, 3 }));
@@ -64,7 +67,7 @@ public class MelodyUtils {
 		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 2, 3, 2 }));
 		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 2, 3, 3 }));
 		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 2, 2, 1 }));
-		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 1, 2, 1 }));
+		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 1, 2, 1 })); // 7
 		//MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 1, 2, 2 }));
 		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 1, 1, 2 }));
 		MELODY_PATTERNS.add(Arrays.asList(new Integer[] { 1, 1, 1, 1 }));
@@ -506,9 +509,8 @@ public class MelodyUtils {
 			rand.setSeed(randomSeed);
 		}
 		if (rand.nextInt(100) < altPatternChance) {
-			List<Integer> altPatternIndices = Arrays.asList(0, 1);
 			return new ArrayList<>(MELODY_PATTERNS
-					.get(altPatternIndices.get(rand.nextInt(altPatternIndices.size()))));
+					.get(ALT_PATTERN_INDEXES.get(rand.nextInt(ALT_PATTERN_INDEXES.size()))));
 		}
 		return new ArrayList<>(MELODY_PATTERNS.get(rand.nextInt(MELODY_PATTERNS.size())));
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
@@ -161,18 +161,19 @@ public class MelodyUtils {
 
 	public static Integer[] getRandomForTypeAndBlockChangeAndLength(Integer type, int blockChange,
 			Integer length, Random melodyBlockGenerator, int approx) {
+		final int clampedBlockChange = OMNI.clamp(blockChange, -7, 7);
 		List<Integer[]> usedList = getBlocksForType(type);
 		// length fits, note distance and distance roughly equal (diff < approx)
 		List<Integer[]> filteredList = usedList.stream()
 				.filter(e -> (length == null || e.length == length)
-						&& (Math.abs(blockChange(e) - Math.abs(blockChange)) <= approx))
+						&& (Math.abs(blockChange(e) - Math.abs(clampedBlockChange)) <= approx))
 				.collect(Collectors.toList());
 		if (filteredList.size() == 0) {
 			return null;
 		}
 		int rand2 = melodyBlockGenerator.nextInt(filteredList.size());
 		Integer[] block = filteredList.get(rand2);
-		if (blockChange(block) == -1 * blockChange) {
+		if (blockChange(block) == -1 * clampedBlockChange) {
 			return inverse(block);
 		} else {
 			return block;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
@@ -542,4 +542,47 @@ public class MelodyUtils {
 				+ main8th.size());
 		return sorted;
 	}
+
+	public static Pair<Integer, Integer[]> generateBlockByBlockChangeAndLength(Integer blockChange,
+			int approx, Random blockNotesGenerator, Integer forcedLength, int remainingVariance,
+			int remainingDirChanges) {
+		// TODO 
+		remainingVariance = Math.max(0, remainingVariance);
+		Random rnd = new Random(blockNotesGenerator.nextInt());
+		int newLen = (forcedLength != null) ? forcedLength : (rnd.nextInt(2) + 3);
+		int last = newLen - 1;
+		Integer[] newBlock = new Integer[newLen];
+		newBlock[0] = 0;
+		newBlock[last] = Math.abs(blockChange) + rnd.nextInt(approx * 2 + 1) - approx;
+		if (blockChange < 0 && newBlock[last] > 0) {
+			newBlock[last] *= -1;
+		}
+		int currentMin = Math.min(0, newBlock[last]);
+		int currentMax = Math.max(0, newBlock[last]);
+
+		for (int i = 1; i < last; i++) {
+			newBlock[i] = rnd.nextInt(remainingVariance * 2 + (currentMax - currentMin) + 1)
+					+ currentMin - remainingVariance;
+			// between lowest note and lowest possible note
+			int varianceOverlapLow = currentMin - newBlock[i];
+			if (varianceOverlapLow > 0) {
+				remainingVariance -= varianceOverlapLow;
+				currentMin = newBlock[i];
+			}
+			// between highest note and highest possible note
+			int varianceOverlapHigh = newBlock[i] - currentMax;
+			if (varianceOverlapHigh > 0) {
+				remainingVariance -= varianceOverlapHigh;
+				currentMax = newBlock[i];
+			}
+			remainingVariance = Math.max(0, remainingVariance);
+		}
+
+
+		/*viableBlocks.removeIf(e -> MelodyUtils.variance(e.getRight()) > remainingVariance);
+		viableBlocks.removeIf(
+				e -> MelodyUtils.interblockDirectionChange(e.getRight()) > remainingDirChanges);*/
+		LG.i("generateBlockByBlockChangeAndLength: " + StringUtils.join(newBlock, ","));
+		return Pair.of(Integer.MAX_VALUE, newBlock);
+	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MelodyUtils.java
@@ -582,7 +582,7 @@ public class MelodyUtils {
 		/*viableBlocks.removeIf(e -> MelodyUtils.variance(e.getRight()) > remainingVariance);
 		viableBlocks.removeIf(
 				e -> MelodyUtils.interblockDirectionChange(e.getRight()) > remainingDirChanges);*/
-		LG.i("generateBlockByBlockChangeAndLength: " + StringUtils.join(newBlock, ","));
+		LG.d("generateBlockByBlockChangeAndLength: " + StringUtils.join(newBlock, ","));
 		return Pair.of(Integer.MAX_VALUE, newBlock);
 	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -2951,7 +2951,10 @@ public class MidiGenerator implements JMC {
 				adjustArrangementPresencesIfNeeded(sec, arr.getSections().get(secOrder - 1));
 			}*/
 
-			fillMelodyPartsForSection(measureLength, overridden, sec, notesSeedOffset,
+			double currentMeasureLength = (sec.getSectionDuration() > 0) ? sec.getSectionDuration()
+					: measureLength;
+
+			fillMelodyPartsForSection(currentMeasureLength, overridden, sec, notesSeedOffset,
 					sectionVariations, sectionChordsReplaced);
 
 			if (logPerformance) {
@@ -2968,7 +2971,7 @@ public class MidiGenerator implements JMC {
 			}
 
 			fillOtherPartsForSection(sec, arr, overridden, sectionVariations, variationGen, arrSeed,
-					measureLength);
+					currentMeasureLength);
 
 			if (logPerformance) {
 				LG.i("After fill other, at: " + (System.currentTimeMillis() - systemTime));
@@ -2979,8 +2982,7 @@ public class MidiGenerator implements JMC {
 				restoreGlobalPartsToGuiConfig();
 			}
 			counter += sec.getMeasures();
-			sectionStartTimer += ((sec.getSectionDuration() > 0) ? sec.getSectionDuration()
-					: measureLength) * sec.getMeasures();
+			sectionStartTimer += currentMeasureLength * sec.getMeasures();
 
 			if (logPerformance) {
 				LG.i("End of section, at: " + (System.currentTimeMillis() - systemTime));

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -3802,6 +3802,10 @@ public class MidiGenerator implements JMC {
 	}
 
 	public boolean replaceWithSectionCustomChordDurations(Section sec) {
+		if (!sec.isCustomChordsEnabled() && !sec.isCustomDurationsEnabled()) {
+			return false;
+		}
+
 		List<String> chords = sec.getCustomChordsList();
 		if ((chords == null || chords.isEmpty()) && sec.isCustomChordsEnabled()) {
 			return false;
@@ -3871,6 +3875,10 @@ public class MidiGenerator implements JMC {
 
 		sec.setSectionBeatDurations(progressionDurations);
 		sec.setSectionDuration(progressionDurations.stream().mapToDouble(e -> e).sum());
+		if (!sec.isCustomChordsEnabled()) {
+			sec.setCustomChords(StringUtils.join(chords, ","));
+			sec.setDisplayAlternateChords(true);
+		}
 		LG.i("Using SECTION custom progression: " + StringUtils.join(chords, ","));
 
 		return true;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -3416,23 +3416,26 @@ public class MidiGenerator implements JMC {
 		if (gc.isBassEnable() && !gc.getBassParts().isEmpty()) {
 			List<Phrase> copiedPhrases = new ArrayList<>();
 			Set<Integer> presences = sec.getPresence(1);
-			boolean added = presences.contains(gc.getBassParts().get(0).getOrder());
-			if (added) {
-				List<Integer> variations = (overridden) ? sec.getVariation(1, 0) : null;
-				BassPart bp = gc.getBassParts().get(0);
-				Phrase b = fillBassFromPart(bp, rootProgression, sec, variations);
+			for (int i = 0; i < gc.getBassParts().size(); i++) {
+				BassPart bp = (BassPart) gc.getBassParts().get(i);
+				boolean added = presences.contains(bp.getOrder());
+				if (added) {
+					List<Integer> variations = (overridden) ? sec.getVariation(1, i) : null;
+					Phrase b = fillBassFromPart(bp, rootProgression, sec, variations);
 
-				if (bp.isDoubleOct()) {
-					b = JMusicUtilsCustom.doublePhrase(b, 12, false, -15);
-					b.setStartTime(START_TIME_DELAY);
+					if (bp.isDoubleOct()) {
+						b = JMusicUtilsCustom.doublePhrase(b, 12, false, -15);
+						b.setStartTime(START_TIME_DELAY);
+					}
+					if (bassParts.get(i).getInstrument() != bp.getInstrument()) {
+						b.setInstrument(bp.getInstrument());
+					}
+					copiedPhrases.add(b);
+				} else {
+					copiedPhrases.add(emptyPhrase.copy());
 				}
-				if (bassParts.get(0).getInstrument() != bp.getInstrument()) {
-					b.setInstrument(bp.getInstrument());
-				}
-				copiedPhrases.add(b);
-			} else {
-				copiedPhrases.add(emptyPhrase.copy());
 			}
+
 			sec.setBasses(copiedPhrases);
 		}
 
@@ -3534,15 +3537,19 @@ public class MidiGenerator implements JMC {
 
 		rand.setSeed(arrSeed + 10);
 		variationGen.setSeed(arrSeed + 10);
-		if (gc.isBassEnable() && !gc.getBassParts().isEmpty()
-				&& !gc.getBassParts().get(0).isMuted()) {
+		if (gc.isBassEnable() && !gc.getBassParts().isEmpty()) {
 			Set<Integer> presences = sec.getPresence(1);
-			boolean added = (overridden && presences.contains(gc.getBassParts().get(0).getOrder()))
-					|| (!overridden && rand.nextInt(100) < sec.getBassChance());
-			added &= gc.getArrangement().isPartInclusion(1, 0, notesSeedOffset);
-			if (added) {
-				if (!overridden)
-					sec.setPresence(1, 0);
+			for (int i = 0; i < gc.getBassParts().size(); i++) {
+				BassPart bp = (BassPart) gc.getBassParts().get(i);
+				rand.setSeed(arrSeed + 50 + bp.getOrder());
+				variationGen.setSeed(arrSeed + 50 + bp.getOrder());
+				boolean added = (overridden && presences.contains(bp.getOrder()))
+						|| (!overridden && rand.nextInt(100) < sec.getBassChance());
+				added &= gc.getArrangement().isPartInclusion(1, i, notesSeedOffset);
+				if (added && !bp.isMuted()) {
+					if (!overridden)
+						sec.setPresence(1, i);
+				}
 			}
 		}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -510,7 +510,7 @@ public class MidiGenerator implements JMC {
 						&& gc.getMelodyPatternEffect() > 0) {
 					List<MelodyBlock> storedMelodyBlocks = new ArrayList<>(
 							existingPattern.getRight());
-					LG.i("HALF PATTERN - set last melody block to newly generated block! Sizes equal?: "
+					LG.d("HALF PATTERN - set last melody block to newly generated block! Sizes equal?: "
 							+ (storedMelodyBlocks.size() == melodyBlocks.size()));
 					storedMelodyBlocks.set(storedMelodyBlocks.size() - 1,
 							melodyBlocks.get(melodyBlocks.size() - 1));
@@ -2691,7 +2691,7 @@ public class MidiGenerator implements JMC {
 
 			// reset back to normal?
 			boolean sectionChordsReplaced = false;
-			if (sec.isCustomChordsDurationsEnabled()) {
+			if (sec.isCustomChordsEnabled()) {
 				sectionChordsReplaced = replaceWithSectionCustomChordDurations(sec);
 			} else {
 				sec.setGeneratedSectionBeatDurations(new ArrayList<>(progressionDurations));
@@ -3147,11 +3147,11 @@ public class MidiGenerator implements JMC {
 					double intersection;
 					if (!sixteenthAlignedDrumHits.isEmpty()) {
 						intersection = sixteenthAlignedDrumHits.get(0);
-						LG.i("Found 16th intersections: " + intersection + ", note start: "
+						LG.d("Found 16th intersections: " + intersection + ", note start: "
 								+ (currTime + n.getOffset()));
 					} else {
 						intersection = intersectingDrumHits.get(0);
-						LG.i("No 16th intersections: " + intersection + ", note start: "
+						LG.d("No 16th intersections: " + intersection + ", note start: "
 								+ (currTime + n.getOffset()));
 					}
 					int noteInsertionIndex = i + addedNotes;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -774,10 +774,16 @@ public class MidiGenerator implements JMC {
 			//int length = blockNotesGenerator.nextInt(100) < gc.getMelodyQuickness() ? 4 : 3;
 
 			blockNotesGenerator.setSeed(melodyBlockGeneratorSeed + blockIndex);
-			Pair<Integer, Integer[]> typeBlock = MelodyUtils.getRandomByApproxBlockChangeAndLength(
-					blockChanges.get(blockIndex), maxJump, blockNotesGenerator,
-					(forcedLengths != null ? forcedLengths.get(blockIndex) : null),
-					remainingVariance, remainingDirChanges);
+			boolean GENERATE_NEW_BLOCKS = false;
+			Pair<Integer, Integer[]> typeBlock = (GENERATE_NEW_BLOCKS)
+					? MelodyUtils.generateBlockByBlockChangeAndLength(blockChanges.get(blockIndex),
+							maxJump, blockNotesGenerator,
+							(forcedLengths != null ? forcedLengths.get(blockIndex) : null),
+							remainingVariance, remainingDirChanges)
+					: MelodyUtils.getRandomByApproxBlockChangeAndLength(
+							blockChanges.get(blockIndex), maxJump, blockNotesGenerator,
+							(forcedLengths != null ? forcedLengths.get(blockIndex) : null),
+							remainingVariance, remainingDirChanges);
 			Integer[] blockNotesArray = typeBlock.getRight();
 			int blockType = typeBlock.getLeft();
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -5081,6 +5081,8 @@ public class MidiGenerator implements JMC {
 								: Durations.WHOLE_NOTE / ((double) repeatedArpsPerChord);
 				int[] chord = convertChordToLength(actualProgression.get(chordIndex),
 						ip.getChordNotesStretch(), ip.isStretchEnabled());
+				/*List<Integer> chordNotes = Arrays.stream(chord).boxed().map(e -> e % 12)
+						.collect(Collectors.toList());*/
 				if (directions != null) {
 					ArpPattern pat = (directions.get(chordIndex)) ? ArpPattern.UP : ArpPattern.DOWN;
 					arpPattern = pat.getPatternByLength(ip.getHitsPerPattern(), chord.length,
@@ -5147,12 +5149,18 @@ public class MidiGenerator implements JMC {
 
 					int pitch = MidiUtils.getXthChordNote(patternNum, chord);
 					if ((contourInterval != null) && (spannedPulseCounter % contourInterval == 0)) {
-						pitch = 24 + MidiUtils.getXthChordNote(arpContourSpanned.get(
+						int newPitch = 24 + MidiUtils.getXthChordNote(arpContourSpanned.get(
 								(spannedPulseCounter / contourInterval) % arpContourSpanned.size()),
 								MidiUtils.cChromatic);
-						LG.i("Replaced with ARP contour pitch: " + pitch + ", at pulse: " + pulse
+						if (ip.isArpContourChordMode()) {
+							newPitch += rootProgression.get(chordIndex)[0] % 12;
+							newPitch = MidiUtils.octavePitch(newPitch) + MidiUtils
+									.getClosestPitchFromList(MidiUtils.MAJ_SCALE, newPitch);
+						}
+						pitch = newPitch;
+						/*LG.i("Replaced with ARP contour pitch: " + pitch + ", at pulse: " + pulse
 								+ ", spanned: " + spannedPulseCounter + ", #: "
-								+ spannedPulseCounter / contourInterval);
+								+ spannedPulseCounter / contourInterval);*/
 					}
 
 					if (gc.isUseOctaveAdjustments() || forceRandomOct) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -1939,7 +1939,7 @@ public class MidiGenerator implements JMC {
 		if (fixedLength == 8) {
 			int[] replacementOrder = new int[] { 4, 7, 5, 6 };
 			for (int i : replacementOrder) {
-				if (similarityGenerator.nextInt() < gc.getLongProgressionSimilarity()) {
+				if (similarityGenerator.nextInt(100) < gc.getLongProgressionSimilarity()) {
 					chordProgList.set(i, chordProgList.get(i - 4));
 					LG.i("Replaced " + i + "-th chord!");
 				} else if (i == 5) {
@@ -2124,7 +2124,7 @@ public class MidiGenerator implements JMC {
 		if (fixedLength == 8) {
 			int[] replacementOrder = new int[] { 4, 7, 5, 6 };
 			for (int i : replacementOrder) {
-				if (similarityGenerator.nextInt() < gc.getLongProgressionSimilarity()) {
+				if (similarityGenerator.nextInt(100) < gc.getLongProgressionSimilarity()) {
 					chordInts.set(i, chordInts.get(i - 4));
 					cpr.set(i, cpr.get(i - 4).clone());
 					LG.i("Replaced " + i + "-th chord!");

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -5128,7 +5128,6 @@ public class MidiGenerator implements JMC {
 							/ melodyPattern.size();
 				}
 				int lastMelodyIndex = 0;
-				boolean melodyNoteCorrections = true;
 
 				int p = 0;
 				double durationNow = 0;
@@ -5147,7 +5146,7 @@ public class MidiGenerator implements JMC {
 						pitch += octaveAdjustmentFromPattern + octaveAdjustGenerated;
 					}
 
-					if (melodyNoteCorrections) {
+					if (gc.isRandomArpCorrectMelodyNotes()) {
 						Integer melodyPitch = null;
 						if (melodySubdivisions > 0) {
 							for (int mInd = lastMelodyIndex; mInd < melodyPattern.size(); mInd++) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -2699,7 +2699,8 @@ public class MidiGenerator implements JMC {
 				sec.setGeneratedSectionBeatDurations(new ArrayList<>(progressionDurations));
 			}
 			if (!sectionChordsReplaced) {
-				if (sectionVariations.get(1) > 0) {
+				if (sectionVariations.get(1) > 0 && alternateChords != null
+						&& !alternateChords.isEmpty()) {
 					//LG.d("Section Variation: Chord Swap!");
 					rootProgression = melodyBasedRootProgression;
 					chordProgression = melodyBasedChordProgression;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -4528,6 +4528,11 @@ public class MidiGenerator implements JMC {
 						if (joinApplicable) {
 							nextP = p + 1;
 							while (nextP < pattern.size()) {
+								if (durationNow + duration * durMultiplier > progressionDurations
+										.get(chordIndex)) {
+									break;
+								}
+
 								if (Integer.signum(pattern.get(nextP)) == stretchedByNote
 										|| pattern.get(nextP) == -1) {
 									durMultiplier++;
@@ -4571,6 +4576,9 @@ public class MidiGenerator implements JMC {
 
 						durationNow += duration;
 						p = (p + 1) % pattern.size();
+						if (p == 0) {
+							nextP = -1;
+						}
 					}
 					chordSpanPart = (chordSpanPart + 1) % ip.getChordSpan();
 				}
@@ -4890,6 +4898,10 @@ public class MidiGenerator implements JMC {
 					if (joinApplicable) {
 						nextP = p + 1;
 						while (nextP < pattern.size()) {
+							if (durationNow + duration * durMultiplier
+									+ DBL_ERR > progressionDurations.get(chordIndex)) {
+								break;
+							}
 							if (Integer.signum(pattern.get(nextP)) == stretchedByNote
 									|| pattern.get(nextP) == -1) {
 								durMultiplier++;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -5163,9 +5163,10 @@ public class MidiGenerator implements JMC {
 									.round((durationNow + chordDurationArp) / melodySubdivisions);
 						}
 
-						LG.i("Last MelodyIndex: " + lastMelodyIndex + ", pitch: " + melodyPitch);
-
 						if (melodyPitch != null) {
+
+							LG.i("Last MelodyIndex: " + lastMelodyIndex + ", pitch: "
+									+ melodyPitch);
 							if (MidiUtils.getSemitonalDistance(melodyPitch, pitch) == 1) {
 								LG.i("Old pitch: " + pitch);
 								pitch = MidiUtils.octavePitch(pitch) + (melodyPitch % 12)

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -480,12 +480,15 @@ public class MidiGenerator implements JMC {
 										remainingDirChanges);
 				remainingDirChanges -= blockChangesPair.getRight();
 				List<Integer> blockChanges = blockChangesPair.getLeft();
-				boolean FLEXIBLE_PATTERN = gc.isMelodyPatternFlexible();
+				boolean FLEXIBLE_PATTERN = mp.isPatternFlexible() && blockChanges.size() > 1;
 				if (FLEXIBLE_PATTERN && existingPattern != null) {
 					int blockChangesSum = blockChanges.stream().mapToInt(e -> e).sum();
-					int newLastBlockChange = blockChanges.get(blockChanges.size() - 1)
-							+ (chord2 - chord1) - blockChangesSum;
-					blockChanges.set(blockChanges.size() - 1, newLastBlockChange);
+					int newLastBlockChange = blockChanges.get(blockChanges.size() - 1);
+					newLastBlockChange += (chord2 - chord1) - blockChangesSum;
+					List<Integer> newBlockChanges = new ArrayList<>(blockChanges);
+					newBlockChanges.set(blockChanges.size() - 1, newLastBlockChange);
+					blockChanges = newBlockChanges;
+
 				}
 				LG.d("Block changes: " + blockChanges);
 				int startingNote = chord1 % 7;
@@ -505,7 +508,8 @@ public class MidiGenerator implements JMC {
 										forcedLengths, remainingDirChanges);
 				if (FLEXIBLE_PATTERN && existingPattern != null
 						&& gc.getMelodyPatternEffect() > 0) {
-					List<MelodyBlock> storedMelodyBlocks = existingPattern.getRight();
+					List<MelodyBlock> storedMelodyBlocks = new ArrayList<>(
+							existingPattern.getRight());
 					LG.i("HALF PATTERN - set last melody block to newly generated block! Sizes equal?: "
 							+ (storedMelodyBlocks.size() == melodyBlocks.size()));
 					storedMelodyBlocks.set(storedMelodyBlocks.size() - 1,

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGenerator.java
@@ -4059,7 +4059,8 @@ public class MidiGenerator implements JMC {
 
 		ScaleMode scale = (modScale != null) ? modScale : gc.getScaleMode();
 		if (scale != ScaleMode.IONIAN) {
-			MidiUtils.transposePhrase(phr, ScaleMode.IONIAN.noteAdjustScale, scale.noteAdjustScale);
+			MidiUtils.transposePhrase(phr, ScaleMode.IONIAN.noteAdjustScale, scale.noteAdjustScale,
+					gc.isTransposedNotesForceScale());
 		}
 		if ((modTrans + extraTranspose) != 0) {
 			Mod.transpose(phr, modTrans + extraTranspose);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
@@ -198,7 +198,7 @@ public class MidiGeneratorUtils {
 				int chordTargetNote = choices.contains(offset) ? offset
 						: MidiUtils.getClosestFromList(choices,
 								offset + (offsetRandomizer.nextInt(100) < 75 ? 1 : 0));
-				LG.i("Offset old: " + offset + ", C T NOte: " + chordTargetNote);
+				LG.d("Offset old: " + offset + ", C T NOte: " + chordTargetNote);
 				offsets.set(i, (targetMode == 1) ? chordTargetNote + chordOffsets.get(i)
 						: chordTargetNote);
 			}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
@@ -406,7 +406,7 @@ public class MidiGeneratorUtils {
 		// 80 + 15 +- 5 + 100/20 -> 95-105 vel.
 		int newVelocity = velocity + MidiGenerator.BASE_ACCENT + accentGenerator.nextInt(11) - 5
 				+ accent / 20;
-		return OMNI.clamp(newVelocity, 0, 127);
+		return OMNI.clampVel(newVelocity);
 	}
 
 	static void applyCrescendoMultiplierMinimum(List<Note> notes, double maxDuration,

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiGeneratorUtils.java
@@ -406,7 +406,7 @@ public class MidiGeneratorUtils {
 		// 80 + 15 +- 5 + 100/20 -> 95-105 vel.
 		int newVelocity = velocity + MidiGenerator.BASE_ACCENT + accentGenerator.nextInt(11) - 5
 				+ accent / 20;
-		return OMNI.clampVel(newVelocity);
+		return OMNI.clampMidi(newVelocity);
 	}
 
 	static void applyCrescendoMultiplierMinimum(List<Note> notes, double maxDuration,

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
@@ -1626,7 +1626,14 @@ public class MidiUtils {
 	}
 
 	public static String chordStringFromPitches(int[] pitches) {
+		String preferredStartPitch = MidiUtils.SEMITONE_LETTERS.get(pitches[0] % 12);
 		int[] normalized60 = normalizeChord(pitches);
+		for (Entry<String, int[]> nameChords : chordsMap.entrySet()) {
+			if (nameChords.getKey().startsWith(preferredStartPitch)
+					&& Arrays.equals(normalized60, normalizeChord(nameChords.getValue()))) {
+				return nameChords.getKey();
+			}
+		}
 		for (Entry<String, int[]> nameChords : chordsMap.entrySet()) {
 			if (Arrays.equals(normalized60, normalizeChord(nameChords.getValue()))) {
 				return nameChords.getKey();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
 import java.util.Vector;
@@ -276,10 +277,10 @@ public class MidiUtils {
 	private static Map<String, int[]> createChordMap() {
 		Map<String, int[]> chordMap = new HashMap<>();
 
-		for (int i = 1; i <= 7; i++) {
+		for (int i = 0; i < 12; i++) {
 			for (int j = 0; j < SPICE_CHORDS_LIST.size(); j++) {
-				chordMap.put(CHORD_FIRST_LETTERS.get(i - 1) + SPICE_NAMES_LIST.get(j),
-						transposeChord(SPICE_CHORDS_LIST.get(j), diaTransMap.get(i)));
+				chordMap.put(SEMITONE_LETTERS.get(i) + SPICE_NAMES_LIST.get(j),
+						transposeChord(SPICE_CHORDS_LIST.get(j), i));
 			}
 		}
 		return chordMap;
@@ -400,10 +401,12 @@ public class MidiUtils {
 		List<Integer> targetScale = Arrays.asList(ScaleMode.IONIAN.noteAdjustScale);
 
 		for (String ch : chords) {
+			if (ch.contains("6") || ch.contains("#")) {
+				continue;
+			}
 			int transposeByLetter = targetScale
 					.get(CHORD_FIRST_LETTERS.indexOf(ch.substring(0, 1)));
-			if (ch.contains("6")
-					|| !isSpiceValid(transposeByLetter, ch.substring(1), targetScale)) {
+			if (!isSpiceValid(transposeByLetter, ch.substring(1), targetScale)) {
 				continue;
 			}
 			int[] chord = chordsMap.get(ch);
@@ -723,7 +726,7 @@ public class MidiUtils {
 		}
 
 		int[] mappedChord = null;
-		if (chordString.length() >= 2 && "#".equals(chordString.substring(1, 2))) {
+		/*if (chordString.length() >= 2 && "#".equals(chordString.substring(1, 2))) {
 			String testChordString = chordString;
 			testChordString = testChordString.replaceFirst("#", "");
 			mappedChord = chordsMap.get(testChordString);
@@ -732,13 +735,13 @@ public class MidiUtils {
 				for (int i = 0; i < mappedChord.length; i++) {
 					mappedChord[i] = mappedChord[i] + 1;
 				}
-
+		
 				if (inversion != null) {
 					return chordInversion(mappedChord, inversion);
 				}
 				return mappedChord;
 			}
-		}
+		}*/
 
 		mappedChord = chordsMap.get(chordString);
 		if (mappedChord == null) {
@@ -1610,6 +1613,17 @@ public class MidiUtils {
 
 	public static int octavePitch(int pitch) {
 		return pitch - pitch % 12;
+	}
+
+	public static String chordStringFromPitches(int[] pitches) {
+		int[] normalized60 = normalizeChord(pitches);
+		for (Entry<String, int[]> nameChords : chordsMap.entrySet()) {
+			if (Arrays.equals(normalized60, normalizeChord(nameChords.getValue()))) {
+				return nameChords.getKey();
+			}
+		}
+		return makeSpelledChord(normalized60);
+
 	}
 
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
@@ -1089,8 +1089,7 @@ public class MidiUtils {
 					int closestPitch = getClosestFromList(modeToList, searchPitch);
 					int difference = searchPitch - closestPitch;
 					n.setPitch(pitch - difference);
-					/*LG.i(
-							"Not indexed pitch.. " + pitch + ", lowered by.. " + difference);*/
+					//LG.i("Not indexed pitch.. " + pitch + ", lowered by.. " + difference);
 				}
 				continue;
 			}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
@@ -1651,4 +1651,28 @@ public class MidiUtils {
 
 	}
 
+	public static List<Integer> extendListToLength(List<Integer> arpPattern, int actualSize) {
+		if (arpPattern == null) {
+			return null;
+		}
+		int listSize = arpPattern.size();
+		if (actualSize == 0 || listSize == 0) {
+			return new ArrayList<>();
+		}
+
+		if (actualSize < listSize) {
+			return arpPattern.subList(0, actualSize);
+		}
+
+		if (actualSize == listSize) {
+			return arpPattern;
+		}
+
+		List<Integer> extendedList = new ArrayList<>(arpPattern);
+		for (int i = listSize; i < actualSize; i++) {
+			extendedList.add(arpPattern.get(i - listSize) % listSize);
+		}
+		return extendedList;
+	}
+
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
@@ -147,6 +147,9 @@ public class MidiUtils {
 	public static final int[] cMaj6th4 = { Pitches.C4, Pitches.E4, Pitches.G4, Pitches.A4 };
 	public static final int[] cMin6th4 = { Pitches.C4, Pitches.EF4, Pitches.G4, Pitches.A4 };
 
+	public static final int[] cChromatic = { Pitches.C4, Pitches.D4, Pitches.E4, Pitches.F4,
+			Pitches.G4, Pitches.A4, Pitches.B4 };
+
 	public static final List<int[]> SPICE_CHORDS_LIST = new ArrayList<>();
 
 	static {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
@@ -999,6 +999,11 @@ public class MidiUtils {
 	}
 
 	public static int[] transposeChord(int[] chord, final Integer[] mode, final Integer[] modeTo) {
+		return transposeChord(chord, mode, modeTo, false);
+	}
+
+	public static int[] transposeChord(int[] chord, final Integer[] mode, final Integer[] modeTo,
+			boolean keepOutliers) {
 		int[] transposedChord = new int[chord.length];
 
 		List<Integer> modeList = new ArrayList<>();
@@ -1015,7 +1020,7 @@ public class MidiUtils {
 			int searchPitch = Integer.valueOf(pitch % 12);
 			int originalIndex = modeList.indexOf(searchPitch);
 
-			if (originalIndex == -1) {
+			if (originalIndex == -1 && !keepOutliers) {
 				if (modeToList.contains(searchPitch)) {
 					//LG.i("Pitch found only in modeTo, not changing: " + pitch);
 				} else {
@@ -1028,15 +1033,20 @@ public class MidiUtils {
 				continue;
 			}
 
+			if (originalIndex >= 0) {
+				int originalMovement = mode[originalIndex];
+				int newMovement = modeTo[originalIndex];
 
-			int originalMovement = mode[originalIndex];
-			int newMovement = modeTo[originalIndex];
-
-			if (pitch != Note.REST) {
-				transposedChord[j] = pitch - originalMovement + newMovement;
+				if (pitch != Note.REST) {
+					transposedChord[j] = pitch - originalMovement + newMovement;
+				} else {
+					transposedChord[j] = pitch;
+				}
 			} else {
 				transposedChord[j] = pitch;
 			}
+
+
 		}
 		return transposedChord;
 	}
@@ -1330,7 +1340,7 @@ public class MidiUtils {
 			}*/
 		}
 		for (Chord c : chords) {
-			c.setNotes(transposeChord(c.getNotes(), detectionResult.getKey().noteAdjustScale,
+			c.setNotes(transposeChord(c.getNotes(), targetMode.noteAdjustScale,
 					ScaleMode.IONIAN.noteAdjustScale));
 		}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
@@ -1651,7 +1651,7 @@ public class MidiUtils {
 
 	}
 
-	public static List<Integer> extendListToLength(List<Integer> arpPattern, int actualSize) {
+	public static List<Integer> sublistIfPossible(List<Integer> arpPattern, int actualSize) {
 		if (arpPattern == null) {
 			return null;
 		}
@@ -1661,18 +1661,18 @@ public class MidiUtils {
 		}
 
 		if (actualSize < listSize) {
-			return arpPattern.subList(0, actualSize);
+			return new ArrayList<>(arpPattern.subList(0, actualSize));
 		}
-
-		if (actualSize == listSize) {
+		return arpPattern;
+		/*if (actualSize == listSize) {
 			return arpPattern;
 		}
-
+		
 		List<Integer> extendedList = new ArrayList<>(arpPattern);
 		for (int i = listSize; i < actualSize; i++) {
 			extendedList.add(arpPattern.get(i - listSize) % listSize);
 		}
-		return extendedList;
+		return extendedList;*/
 	}
 
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/MidiUtils.java
@@ -65,7 +65,10 @@ public class MidiUtils {
 				INDIAN_SCALE = { 0, 1, 1, 4, 5, 8, 10 }, LOCRIAN_SCALE = { 0, 1, 3, 4, 6, 8, 10 },
 				HARMONIC_MAJOR_SCALE = { 0, 2, 4, 5, 7, 8, 11 },
 				WHISKEY_SCALE = { 0, 3, 5, 6, 7, 10, 11 },
-				DOUBLE_HARM_SCALE = { 0, 1, 4, 5, 7, 8, 11 };
+				DOUBLE_HARM_SCALE = { 0, 1, 4, 5, 7, 8, 11 },
+				BBORIAN_SCALE = { 1, 2, 4, 6, 7, 9, 11 }, EBOLIAN_SCALE = { 1, 2, 4, 6, 8, 9, 11 },
+				ABRYGIAN_SCALE = { 1, 3, 4, 6, 8, 9, 11 },
+				DBOCRIAN_SCALE = { 1, 3, 4, 6, 8, 10, 11 }, GBFS_SCALE = { 1, 3, 5, 6, 8, 10, 11 };
 
 	}
 
@@ -96,7 +99,10 @@ public class MidiUtils {
 		LOCRIAN(Scales.LOCRIAN_SCALE, 4), BLUES(Scales.BLUES_SCALE, -1),
 		HARM_MINOR(Scales.HARMONIC_MINOR_SCALE, 5), TURKISH(Scales.TURKISH_SCALE, -1),
 		INDIAN(Scales.INDIAN_SCALE, 2), HARM_MAJOR(Scales.HARMONIC_MAJOR_SCALE, 5),
-		WHISKEY(Scales.WHISKEY_SCALE, 1), DOUBLE_HARM(Scales.DOUBLE_HARM_SCALE, 1);
+		WHISKEY(Scales.WHISKEY_SCALE, 1), DOUBLE_HARM(Scales.DOUBLE_HARM_SCALE, 1),
+		BBORIAN(Scales.BBORIAN_SCALE, 0), EBOLIAN(Scales.EBOLIAN_SCALE, 4),
+		ABRYGIAN(Scales.ABRYGIAN_SCALE, 1), DBOCRIAN(Scales.DBOCRIAN_SCALE, 6),
+		GBFS(Scales.GBFS_SCALE, 2);
 
 		public Integer[] noteAdjustScale;
 		public Integer modeTargetNote;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/OMNI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/OMNI.java
@@ -88,7 +88,11 @@ public class OMNI {
 	}
 
 	public static int clampVel(double d) {
-		return clamp((int) d, 0, 127);
+		return clampVel((int) d);
+	}
+
+	public static int clampVel(int d) {
+		return clamp(d, 0, 127);
 	}
 
 	public static <T> T getWeightedValue(T[] values, int searchedWeight, int[] weights) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/OMNI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/OMNI.java
@@ -88,10 +88,10 @@ public class OMNI {
 	}
 
 	public static int clampVel(double d) {
-		return clampVel((int) d);
+		return clampMidi((int) d);
 	}
 
-	public static int clampVel(int d) {
+	public static int clampMidi(int d) {
 		return clamp(d, 0, 127);
 	}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ArpPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ArpPanel.java
@@ -110,9 +110,6 @@ public class ArpPanel extends InstPanel {
 		for (ArpPattern d : ArpPattern.values()) {
 			arpPattern.addItem(d);
 		}
-
-		removeButton.addActionListener(l);
-		removeButton.setActionCommand("RemoveArp," + panelOrder);
 	}
 
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ArpPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ArpPanel.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.vibehistorian.vibecomposer.MelodyUtils;
 import org.vibehistorian.vibecomposer.OMNI;
 import org.vibehistorian.vibecomposer.Components.ArpPickerMini;
+import org.vibehistorian.vibecomposer.Components.CheckButton;
 import org.vibehistorian.vibecomposer.Components.RandomIntegerListButton;
 import org.vibehistorian.vibecomposer.Components.ScrollComboBox;
 import org.vibehistorian.vibecomposer.Enums.ArpPattern;
@@ -30,6 +31,7 @@ public class ArpPanel extends InstPanel {
 
 	private ArpPickerMini arpPattern = new ArpPickerMini(this);
 	private RandomIntegerListButton arpContour = new RandomIntegerListButton("?", this);
+	private CheckButton arpContourChordMode = new CheckButton("C", true);
 	private KnobPanel arpPatternRotate = new KnobPanel("Rotate", 0, 0, 8);
 
 	public void initComponents(ActionListener l) {
@@ -83,6 +85,7 @@ public class ArpPanel extends InstPanel {
 		});
 		arpContour.setHighlighterGenerator(null);
 		this.add(arpContour);
+		this.add(arpContourChordMode);
 		this.add(arpPatternRotate);
 
 		this.add(stretchPanel);
@@ -140,6 +143,7 @@ public class ArpPanel extends InstPanel {
 		part.setArpPatternCustom(
 				arpPattern.getVal() == ArpPattern.CUSTOM ? arpPattern.getCustomValues() : null);
 		part.setArpContour(getArpContour());
+		part.setArpContourChordMode(getArpContourChordMode());
 		return part;
 	}
 
@@ -153,6 +157,7 @@ public class ArpPanel extends InstPanel {
 			arpPattern.setCustomValues(part.getArpPatternCustom());
 		}
 		setArpContour(part.getArpContour());
+		setArpContourChordMode(part.isArpContourChordMode());
 	}
 
 	public ArpPattern getArpPattern() {
@@ -195,5 +200,13 @@ public class ArpPanel extends InstPanel {
 
 	public void setArpContour(List<Integer> val) {
 		this.arpContour.setValues(val);
+	}
+
+	public boolean getArpContourChordMode() {
+		return arpContourChordMode.isSelected();
+	}
+
+	public void setArpContourChordMode(boolean val) {
+		this.arpContourChordMode.setSelected(val);
 	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ArpPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ArpPanel.java
@@ -4,13 +4,19 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Insets;
 import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 
 import javax.swing.JButton;
 import javax.swing.JLabel;
 
+import org.apache.commons.lang3.StringUtils;
+import org.vibehistorian.vibecomposer.MelodyUtils;
 import org.vibehistorian.vibecomposer.OMNI;
 import org.vibehistorian.vibecomposer.Components.ArpPickerMini;
+import org.vibehistorian.vibecomposer.Components.RandomIntegerListButton;
 import org.vibehistorian.vibecomposer.Components.ScrollComboBox;
 import org.vibehistorian.vibecomposer.Enums.ArpPattern;
 import org.vibehistorian.vibecomposer.Parts.ArpPart;
@@ -23,6 +29,7 @@ public class ArpPanel extends InstPanel {
 	private static final long serialVersionUID = 6648220153568966988L;
 
 	private ArpPickerMini arpPattern = new ArpPickerMini(this);
+	private RandomIntegerListButton arpContour = new RandomIntegerListButton("?", this);
 	private KnobPanel arpPatternRotate = new KnobPanel("Rotate", 0, 0, 8);
 
 	public void initComponents(ActionListener l) {
@@ -65,6 +72,17 @@ public class ArpPanel extends InstPanel {
 		JLabel notePresetLabel = new JLabel("Dir:");
 		this.add(notePresetLabel);
 		this.add(arpPattern);
+		arpContour.setMargin(new Insets(0, 0, 0, 0));
+		arpContour.setTextGenerator(e -> {
+			return StringUtils.join(arpContour.getRandGenerator().apply(new Object()), ",");
+		});
+		arpContour.setRandGenerator(e -> {
+			Random rnd = new Random();
+			return new ArrayList<>(Arrays
+					.asList(MelodyUtils.getRandomForType(rnd.nextInt(MelodyUtils.NUM_LISTS), rnd)));
+		});
+		arpContour.setHighlighterGenerator(null);
+		this.add(arpContour);
 		this.add(arpPatternRotate);
 
 		this.add(stretchPanel);
@@ -121,6 +139,7 @@ public class ArpPanel extends InstPanel {
 		part.setArpPatternRotate(getArpPatternRotate());
 		part.setArpPatternCustom(
 				arpPattern.getVal() == ArpPattern.CUSTOM ? arpPattern.getCustomValues() : null);
+		part.setArpContour(getArpContour());
 		return part;
 	}
 
@@ -133,6 +152,7 @@ public class ArpPanel extends InstPanel {
 		if (part.getArpPattern() == ArpPattern.CUSTOM) {
 			arpPattern.setCustomValues(part.getArpPatternCustom());
 		}
+		setArpContour(part.getArpContour());
 	}
 
 	public ArpPattern getArpPattern() {
@@ -167,5 +187,13 @@ public class ArpPanel extends InstPanel {
 
 	public void setArpPatternCustom(List<Integer> arpPatternCustom) {
 		arpPattern.setCustomValues(arpPatternCustom);
+	}
+
+	public List<Integer> getArpContour() {
+		return OMNI.parseIntsString(arpContour.getValue());
+	}
+
+	public void setArpContour(List<Integer> val) {
+		this.arpContour.setValues(val);
 	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ChordPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/ChordPanel.java
@@ -142,9 +142,6 @@ public class ChordPanel extends InstPanel {
 				//}
 			}
 		});
-
-		removeButton.addActionListener(l);
-		removeButton.setActionCommand("RemoveChord," + panelOrder);
 	}
 
 	public int getTransitionChance() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/DrumPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/DrumPanel.java
@@ -59,17 +59,22 @@ public class DrumPanel extends InstPanel {
 		JButton doublerButt = new JButton("Dd");
 		doublerButt.setPreferredSize(new Dimension(25, 30));
 		doublerButt.setMargin(new Insets(0, 0, 0, 0));
+		JButton expanderButt = new JButton("<>");
+		expanderButt.setPreferredSize(new Dimension(25, 30));
+		expanderButt.setMargin(new Insets(0, 0, 0, 0));
 		JButton veloTogglerButt = new JButton("V");
 		veloTogglerButt.setPreferredSize(new Dimension(25, 30));
 		veloTogglerButt.setMargin(new Insets(0, 0, 0, 0));
 		comboPanel = makeVisualPatternPanel();
 		comboPanel.linkDoubler(doublerButt);
+		comboPanel.linkExpander(expanderButt);
 		comboPanel.linkVelocityToggle(veloTogglerButt);
 		comboPanel.setBigModeAllowed(true);
 		comboPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 		JPanel comboPanelWrapper = new JPanel();
 
 		comboPanelWrapper.add(doublerButt);
+		comboPanelWrapper.add(expanderButt);
 		comboPanelWrapper.add(comboPanel);
 		comboPanelWrapper.add(veloTogglerButt);
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/DrumPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/DrumPanel.java
@@ -110,8 +110,6 @@ public class DrumPanel extends InstPanel {
 
 	public DrumPanel(ActionListener l) {
 		initComponents(l);
-		removeButton.addActionListener(l);
-		removeButton.setActionCommand("RemoveDrum," + panelOrder);
 	}
 
 	public DrumPart toDrumPart(int lastRandomSeed) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/DrumPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/DrumPanel.java
@@ -48,6 +48,7 @@ public class DrumPanel extends InstPanel {
 
 		// pattern business
 		this.add(hitsPerPattern);
+		hitsPerPattern.setScrollEnabled(false);
 
 		hitsPerPattern.getKnob().setTickThresholds(Arrays.asList(
 				new Integer[] { 4, 6, 8, 10, 12, 16, 24, 32, VisualPatternPanel.MAX_HITS }));
@@ -81,20 +82,25 @@ public class DrumPanel extends InstPanel {
 		this.add(comboPanelWrapper);
 		this.add(patternFlip);
 		this.add(patternShift);
+		patternShift.setScrollEnabled(false);
 		this.add(isVelocityPattern);
 		comboPanel.linkGhostNoteSwitch(isVelocityPattern);
 
 		this.add(chordSpan);
+		chordSpan.setScrollEnabled(false);
 		this.add(pauseChance);
+		pauseChance.setScrollEnabled(false);
 
 		this.add(swingPercent);
+		swingPercent.setScrollEnabled(false);
 
 		this.add(exceptionChance);
+		exceptionChance.setScrollEnabled(false);
 
 		this.add(minMaxVelSlider);
 
 
-		addOffsetAndDelayControls();
+		addOffsetAndDelayControls(false);
 
 
 		this.add(patternSeedLabel);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
@@ -213,10 +213,47 @@ public abstract class InstPanel extends JPanel {
 			}
 		});
 
-		copyButton.addActionListener(l);
+		copyButton.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseClicked(MouseEvent e) {
+				InstPart part = toInstPart(VibeComposerGUI.lastRandomSeed);
+				InstPanel newPanel = VibeComposerGUI.vibeComposerGUI.addInstPanelToLayout(
+						VibeComposerGUI.instrumentTabPane.getSelectedIndex(), part, true);
+				newPanel.setPatternSeed(getPatternSeed());
+
+				// todo checkbox set cc'd panel's midichannel?
+				if (true) {
+					newPanel.setMidiChannel(getMidiChannel());
+				} else {
+					switch (VibeComposerGUI.instrumentTabPane.getSelectedIndex()) {
+					case 2:
+						newPanel.setMidiChannel(11 + (newPanel.getPanelOrder() - 1) % 5);
+						newPanel.setPanByOrder(5);
+						break;
+					case 3:
+						newPanel.setMidiChannel(2 + (newPanel.getPanelOrder() - 1) % 7);
+						newPanel.setPanByOrder(7);
+						break;
+					case 4:
+						newPanel.getComboPanel().reapplyHits();
+						break;
+					default:
+						break;
+					}
+				}
+
+				if (SwingUtilities.isRightMouseButton(e)) {
+					setChordSpanFill(ChordSpanFill.HALF1);
+					newPanel.setChordSpanFill(ChordSpanFill.HALF2);
+				}
+
+				VibeComposerGUI.vibeComposerGUI.recalculateTabPaneCounts();
+				VibeComposerGUI.vibeComposerGUI.recalculateGenerationCounts();
+			}
+
+		});
 		randomizeButton.addActionListener(l);
 
-		copyButton.setActionCommand("CopyPart");
 		copyButton.setPreferredSize(new Dimension(25, 30));
 		copyButton.setMargin(new Insets(0, 0, 0, 0));
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
@@ -98,8 +98,8 @@ public abstract class InstPanel extends JPanel {
 	protected KnobPanel transpose = new KnobPanel("Transpose", 0, -36, 36, 12);
 	protected KnobPanel offset = new KnobPanel("Offset", 0, -1000, 1000);
 	protected KnobPanel feedbackCount = new KnobPanel("Delays", 0, 0, 5);
-	protected KnobPanel feedbackDuration = new KnobPanel("FB Dur.", 500, -2000, 2000);
-	protected KnobPanel feedbackVol = new KnobPanel("FB Vol.", 80, 10, 150);
+	protected KnobPanel feedbackDuration = new KnobPanel("FB Dur.", 750, -2000, 2000);
+	protected KnobPanel feedbackVol = new KnobPanel("FB Vol.", 65, 10, 150);
 
 
 	protected RangeSlider minMaxVelSlider = new RangeSlider(0, 127);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
@@ -74,6 +74,7 @@ public abstract class InstPanel extends JPanel {
 	private static final long serialVersionUID = 4381939543337887617L;
 	public static final int TARGET_RHYTHM_DENSITY = 8;
 	public static final int MAX_RHYTHM_DENSITY = 11;
+	public static final int SMALL_BTN_HEIGHT = 27;
 
 	protected InstComboBox instrument = new InstComboBox();
 	protected InstUtils.POOL instPool = InstUtils.POOL.PLUCK;
@@ -155,7 +156,7 @@ public abstract class InstPanel extends JPanel {
 		for (ChordSpanFill fill : ChordSpanFill.values()) {
 			chordSpanFill.addItem(fill);
 		}
-		panelOrder.setPreferredSize(new Dimension(20, 30));
+		panelOrder.setPreferredSize(new Dimension(20, SMALL_BTN_HEIGHT));
 
 		setBorder(BorderFactory.createBevelBorder(BevelBorder.LOWERED));
 		//volSlider.setMaximum(100);
@@ -188,10 +189,10 @@ public abstract class InstPanel extends JPanel {
 		chordSpanFill.setOpaque(false);
 		chordSpanFillPanel.add(fillFlip);
 
-		muteInst.setPreferredSize(new Dimension(20, 25));
+		muteInst.setPreferredSize(new Dimension(20, SMALL_BTN_HEIGHT));
 		muteInst.setMargin(new Insets(0, 0, 0, 0));
 
-		lockInst.setPreferredSize(new Dimension(20, 25));
+		lockInst.setPreferredSize(new Dimension(20, SMALL_BTN_HEIGHT));
 		lockInst.setMargin(new Insets(0, 0, 0, 0));
 		lockInst.addMouseListener(new MouseAdapter() {
 			@Override
@@ -261,11 +262,14 @@ public abstract class InstPanel extends JPanel {
 		});
 		randomizeButton.addActionListener(l);
 
-		copyButton.setPreferredSize(new Dimension(25, 30));
+		removeButton.setPreferredSize(new Dimension(25, SMALL_BTN_HEIGHT));
+		removeButton.setMargin(new Insets(0, 0, 0, 0));
+
+		copyButton.setPreferredSize(new Dimension(25, SMALL_BTN_HEIGHT));
 		copyButton.setMargin(new Insets(0, 0, 0, 0));
 
 		randomizeButton.setActionCommand("RandomizePart");
-		randomizeButton.setPreferredSize(new Dimension(15, 30));
+		randomizeButton.setPreferredSize(new Dimension(15, SMALL_BTN_HEIGHT));
 		randomizeButton.setMargin(new Insets(0, 0, 0, 0));
 
 		instrument.setPrototype("XXXXXXXXXXXX");

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
@@ -312,6 +312,17 @@ public abstract class InstPanel extends JPanel {
 		this.add(instrument);
 	}
 
+	public void addOffsetAndDelayControls(boolean scrollEnabled) {
+		this.add(offset);
+		offset.setScrollEnabled(false);
+		this.add(feedbackCount);
+		feedbackCount.setScrollEnabled(false);
+		this.add(feedbackDuration);
+		feedbackDuration.setScrollEnabled(false);
+		this.add(feedbackVol);
+		feedbackVol.setScrollEnabled(false);
+	}
+
 	public void addOffsetAndDelayControls() {
 		this.add(offset);
 		this.add(feedbackCount);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
@@ -140,7 +140,7 @@ public abstract class InstPanel extends JPanel {
 	protected PhraseNotes customMidi = null;
 
 	public InstPanel() {
-
+		super(new FlowLayout(FlowLayout.CENTER, 2, 0));
 	}
 
 	public void initDefaultsPost() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
@@ -216,6 +216,9 @@ public abstract class InstPanel extends JPanel {
 		copyButton.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseClicked(MouseEvent e) {
+				if (!copyButton.isEnabled()) {
+					return;
+				}
 				InstPart part = toInstPart(VibeComposerGUI.lastRandomSeed);
 				InstPanel newPanel = VibeComposerGUI.vibeComposerGUI.addInstPanelToLayout(
 						VibeComposerGUI.instrumentTabPane.getSelectedIndex(), part, true);
@@ -242,13 +245,14 @@ public abstract class InstPanel extends JPanel {
 					}
 				}
 
-				if (SwingUtilities.isRightMouseButton(e)) {
+				if (SwingUtilities.isMiddleMouseButton(e)) {
 					setChordSpanFill(ChordSpanFill.HALF1);
 					newPanel.setChordSpanFill(ChordSpanFill.HALF2);
 				}
 
 				VibeComposerGUI.vibeComposerGUI.recalculateTabPaneCounts();
 				VibeComposerGUI.vibeComposerGUI.recalculateGenerationCounts();
+				VibeComposerGUI.vibeComposerGUI.repaint();
 			}
 
 		});
@@ -309,6 +313,10 @@ public abstract class InstPanel extends JPanel {
 	}
 
 	public void addDefaultPanelButtons() {
+		removeButton.addActionListener(e -> {
+			VibeComposerGUI.removeInstPanel(getPartNum(), getPanelOrder(), true);
+			VibeComposerGUI.vibeComposerGUI.recalculateGeneratorAndTabCounts();
+		});
 		this.add(removeButton);
 		this.add(copyButton);
 		this.add(randomizeButton);
@@ -619,8 +627,6 @@ public abstract class InstPanel extends JPanel {
 
 	public void setPanelOrder(int val) {
 		this.panelOrder.setText("" + val);
-		String removeActionString = removeButton.getActionCommand().split(",")[0];
-		removeButton.setActionCommand(removeActionString + "," + val);
 	}
 
 	public boolean getFillFlip() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
@@ -747,7 +747,7 @@ public abstract class InstPanel extends JPanel {
 	public void setPanByOrder(int order, int panelLimit) {
 		order--;
 		getPanSlider().setValue(
-				50 + (order % 2 == 0 ? 1 : -1) * ((order - 1) % panelLimit) * (49 / panelLimit));
+				50 + (order % 2 == 0 ? 1 : -1) * (order % panelLimit) * (49 / panelLimit));
 	}
 
 	public void applyPauseChance(Random randGen) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/InstPanel.java
@@ -118,8 +118,8 @@ public abstract class InstPanel extends JPanel {
 	protected VisualPatternPanel comboPanel = null;
 	protected KnobPanel patternShift = new KnobPanel("Shift", 0, 0, 8);
 
-	protected CheckButton lockInst = new CheckButton("Lock", false);
-	protected CheckButton muteInst = new CheckButton("Excl.", false);
+	protected CheckButton lockInst = new CheckButton("<html>&#x1F512;</html>", false);
+	protected CheckButton muteInst = new CheckButton("Ex", false);
 
 	protected VeloRect volSlider = new VeloRect(0, 100, 100);
 	protected VeloRect panSlider = new VeloRect(0, 100, 50);
@@ -188,23 +188,26 @@ public abstract class InstPanel extends JPanel {
 		chordSpanFill.setOpaque(false);
 		chordSpanFillPanel.add(fillFlip);
 
+		muteInst.setPreferredSize(new Dimension(20, 25));
+		muteInst.setMargin(new Insets(0, 0, 0, 0));
+
+		lockInst.setPreferredSize(new Dimension(20, 25));
+		lockInst.setMargin(new Insets(0, 0, 0, 0));
 		lockInst.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mousePressed(MouseEvent evt) {
 				if (SwingUtilities.isMiddleMouseButton(evt)) {
-					if (evt.isControlDown()) {
-						for (Component c : getComponents()) {
-							if (c instanceof ScrollComboBox) {
-								((ScrollComboBox) c).setEnabled(true);
-							} else if (c instanceof KnobPanel) {
-								((KnobPanel) c).setBlockInput(false);
-							} else if (c instanceof JPanel) {
-								for (Component c2 : ((JPanel) c).getComponents()) {
-									if (c2 instanceof ScrollComboBox) {
-										((ScrollComboBox) c2).setEnabled(true);
-									} else if (c instanceof KnobPanel) {
-										((KnobPanel) c2).setBlockInput(false);
-									}
+					for (Component c : getComponents()) {
+						if (c instanceof ScrollComboBox) {
+							((ScrollComboBox) c).setEnabled(true);
+						} else if (c instanceof KnobPanel) {
+							((KnobPanel) c).setBlockInput(false);
+						} else if (c instanceof JPanel) {
+							for (Component c2 : ((JPanel) c).getComponents()) {
+								if (c2 instanceof ScrollComboBox) {
+									((ScrollComboBox) c2).setEnabled(true);
+								} else if (c instanceof KnobPanel) {
+									((KnobPanel) c2).setBlockInput(false);
 								}
 							}
 						}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/KnobPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/KnobPanel.java
@@ -19,6 +19,7 @@ public class KnobPanel extends TransparentablePanel {
 	boolean showTextInKnob = false;
 	String name = "";
 	LockComponentButton lockButt = null;
+	boolean scrollEnabled = true;
 
 	public KnobPanel(String name, int value) {
 		this(name, value, 0, 100);
@@ -99,6 +100,14 @@ public class KnobPanel extends TransparentablePanel {
 	public void setRegenerating(boolean b) {
 		knob.setRegenerating(b);
 		lockButt.setVisible(false);
+	}
+
+	public boolean isScrollEnabled() {
+		return knob.isScrollEnabled();
+	}
+
+	public void setScrollEnabled(boolean scrollEnabled) {
+		knob.setScrollEnabled(scrollEnabled);
 	}
 
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
@@ -62,6 +62,7 @@ public class MelodyPanel extends InstPanel {
 		this.add(new JLabel("#"));
 		this.add(panelOrder);
 		addDefaultInstrumentControls();
+		addDefaultPanelButtons();
 
 		transpose.getKnob().setTickSpacing(10);
 		Integer[] allowedMelodyTransposes = new Integer[] { 0, 4, 5, 7 };

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
@@ -105,11 +105,10 @@ public class MelodyPanel extends InstPanel {
 			if (relatedSection == null) {
 				return MidiUtils.getHighlightTargetsFromChords(MidiGenerator.chordInts, true);
 			} else {
-				return MidiUtils.getHighlightTargetsFromChords(
-						relatedSection.isCustomChordsEnabled()
+				return MidiUtils
+						.getHighlightTargetsFromChords(relatedSection.isCustomChordsEnabled()
 								? relatedSection.getCustomChordsList()
-								: MidiGenerator.chordInts,
-						true);
+								: MidiGenerator.chordInts, true);
 			}
 
 		});
@@ -276,8 +275,8 @@ public class MelodyPanel extends InstPanel {
 		splitChance.setInt(mp1.splitChance.getInt());
 		noteExceptionChance.setInt(mp1.noteExceptionChance.getInt());
 		speed.setInt(mp1.speed.getInt());
-		leadChordsChance.setInt(mp1.leadChordsChance.getInt());
-		startNoteChance.setInt(mp1.startNoteChance.getInt());
+		//leadChordsChance.setInt(mp1.leadChordsChance.getInt());
+		//startNoteChance.setInt(mp1.startNoteChance.getInt());
 		//setInstrument(mp1.getInstrument());
 	}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
@@ -34,7 +34,7 @@ public class MelodyPanel extends InstPanel {
 	private RandomIntegerListButton patternStructure = new RandomIntegerListButton("1,2,1,3", this);
 	private KnobPanel maxBlockChange = new KnobPanel("Max Block<br>Change +-", 7, 0, 7);
 	private KnobPanel blockJump = new KnobPanel("Block<br>Jump", 1, 0, 4);
-	private KnobPanel maxNoteExceptions = new KnobPanel("Max Note<br>Exc. #", 0, 0, 4);
+	private KnobPanel maxNoteExceptions = new KnobPanel("Max<br>Exc.", 0, 0, 4);
 	private KnobPanel alternatingRhythmChance = new KnobPanel("Alt.<br>Pattern", 33);
 	private KnobPanel doubledRhythmChance = new KnobPanel("Doubled<br>Rhythm%", 0);
 	private KnobPanel splitChance = new KnobPanel("Split<br>Long%", 0);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
@@ -106,7 +106,7 @@ public class MelodyPanel extends InstPanel {
 				return MidiUtils.getHighlightTargetsFromChords(MidiGenerator.chordInts, true);
 			} else {
 				return MidiUtils.getHighlightTargetsFromChords(
-						relatedSection.isCustomChordsDurationsEnabled()
+						relatedSection.isCustomChordsEnabled()
 								? relatedSection.getCustomChordsList()
 								: MidiGenerator.chordInts,
 						true);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
@@ -46,7 +46,8 @@ public class MelodyPanel extends InstPanel {
 
 	public void initComponents(ActionListener l) {
 
-		ScrollComboBox.addAll(new Integer[] { 1, 7, 8, 15 }, midiChannel);
+		ScrollComboBox.addAll(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15 },
+				midiChannel);
 		midiChannel.setVal(1);
 		instPool = POOL.MELODY;
 		instrument.initInstPool(instPool);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
@@ -42,6 +42,7 @@ public class MelodyPanel extends InstPanel {
 	private KnobPanel speed = new KnobPanel("Speed", 50);
 	private KnobPanel leadChordsChance = new KnobPanel("Lead To<br>Chords%", 25);
 	private KnobPanel startNoteChance = new KnobPanel("Start%", 80);
+	private JCheckBox patternFlexible = new CustomCheckBox("Flex", true);
 
 	public void initComponents(ActionListener l) {
 
@@ -127,6 +128,7 @@ public class MelodyPanel extends InstPanel {
 			return MelodyUtils.getRandomMelodyPattern(getAlternatingRhythmChance(),
 					new Random().nextInt());
 		});
+		this.add(patternFlexible);
 
 		this.add(blockJump);
 		this.add(maxNoteExceptions);
@@ -208,6 +210,7 @@ public class MelodyPanel extends InstPanel {
 		part.setNoteExceptionChance(getNoteExceptionChance());
 		part.setSpeed(getSpeed());
 		part.setSplitChance(getSplitChance());
+		part.setPatternFlexible(getPatternFlexible());
 
 		return part;
 	}
@@ -230,6 +233,7 @@ public class MelodyPanel extends InstPanel {
 		setNoteExceptionChance(part.getNoteExceptionChance());
 		setSpeed(part.getSpeed());
 		setSplitChance(part.getSplitChance());
+		setPatternFlexible(part.isPatternFlexible());
 	}
 
 	@Override
@@ -373,6 +377,14 @@ public class MelodyPanel extends InstPanel {
 	@Override
 	public Class<? extends InstPart> getPartClass() {
 		return MelodyPart.class;
+	}
+
+	public boolean getPatternFlexible() {
+		return patternFlexible.isSelected();
+	}
+
+	public void setPatternFlexible(boolean val) {
+		this.patternFlexible.setSelected(val);
 	}
 }
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
@@ -254,7 +254,7 @@ public class MelodyPanel extends InstPanel {
 	}
 
 	public void setChordNoteChoices(List<Integer> val) {
-		this.noteTargets.setValue(StringUtils.join(val, ","));
+		this.noteTargets.setValues(val);
 	}
 
 	public List<Integer> getMelodyPatternOffsets() {
@@ -262,7 +262,7 @@ public class MelodyPanel extends InstPanel {
 	}
 
 	public void setMelodyPatternOffsets(List<Integer> val) {
-		this.patternStructure.setValue(StringUtils.join(val, ","));
+		this.patternStructure.setValues(val);
 	}
 
 	public void overridePatterns(MelodyPanel mp1) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/MelodyPanel.java
@@ -52,7 +52,7 @@ public class MelodyPanel extends InstPanel {
 		instrument.initInstPool(instPool);
 		setInstrument(73);
 		initDefaults(l);
-		volSlider.setDefaultValue(69);
+		volSlider.setDefaultValue(50);
 		setVelocityMin(80);
 		setVelocityMax(105);
 		this.add(volSlider);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
@@ -30,8 +30,6 @@ import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
-import org.apache.commons.lang3.StringUtils;
-import org.vibehistorian.vibecomposer.LG;
 import org.vibehistorian.vibecomposer.MidiGenerator;
 import org.vibehistorian.vibecomposer.MidiGenerator.Durations;
 import org.vibehistorian.vibecomposer.MidiUtils;
@@ -869,10 +867,10 @@ public class VisualPatternPanel extends JPanel {
 		}
 
 
-		LG.i(parentPanel.getPanelOrder() + "#");
+		/*LG.i(parentPanel.getPanelOrder() + "#");
 		LG.i("Quarter notes: " + currentPatternTime);
 		LG.i(StringUtils.join(prevChordDurations, ", "));
-		LG.i("Chord num: " + chordNumInMeasure);
+		LG.i("Chord num: " + chordNumInMeasure);*/
 		List<Integer> fillPattern = parentPanel.getChordSpanFill().getPatternByLength(totalChords,
 				parentPanel.getFillFlip());
 
@@ -901,12 +899,12 @@ public class VisualPatternPanel extends JPanel {
 		for (int i = 0; i < indexOfSubtractableDurations; i++) {
 			currentPatternTime -= prevChordDurations.get(i);
 		}
-		LG.i("Quarter notes: " + currentPatternTime);
 
 		double patternTotalDuration = Durations.WHOLE_NOTE * chordSpan;
 		double percentage = (currentPatternTime / patternTotalDuration);
+		/*LG.i("Quarter notes: " + currentPatternTime);
 		LG.i("Percentage raw: " + percentage);
-		LG.i("Last chord duration: " + currentChordDuration);
+		LG.i("Last chord duration: " + currentChordDuration);*/
 
 		double patternCoverage = currentChordDuration / Durations.WHOLE_NOTE;
 		/*if (chordSpan > 1 && patternRepeat != 3 && patternCoverage > 1 + MidiGenerator.DBL_ERR) {
@@ -921,7 +919,7 @@ public class VisualPatternPanel extends JPanel {
 			// percentage within a chord part
 			normalizedPercentage -= (chordSpan == 4) ? SPAN_4_ZONES[chordSpanPart]
 					: SPAN_2_ZONES[chordSpanPart];
-			LG.i("Percentage norm (current chord): " + normalizedPercentage);
+			//LG.i("Percentage norm (current chord): " + normalizedPercentage);
 
 			double repeatThreshold = (chordSpan == 4) ? 0.25 : 0.5;
 			double newPercentage = normalizedPercentage % patternCoverage;
@@ -940,7 +938,7 @@ public class VisualPatternPanel extends JPanel {
 		percentage *= patternRepeat;
 		// 10 for modulo calc
 		percentage = (10.0 + percentage) % 1.0;
-		LG.i("Percentage: " + percentage);
+		//LG.i("Percentage: " + percentage);
 		int highlightedHit = (int) Math.floor(percentage * lastHits);
 		if (highlightedHit < 0) {
 			highlightedHit = 0;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
@@ -32,6 +32,7 @@ import javax.swing.event.DocumentListener;
 
 import org.apache.commons.lang3.StringUtils;
 import org.vibehistorian.vibecomposer.LG;
+import org.vibehistorian.vibecomposer.MidiGenerator;
 import org.vibehistorian.vibecomposer.MidiGenerator.Durations;
 import org.vibehistorian.vibecomposer.MidiUtils;
 import org.vibehistorian.vibecomposer.OMNI;
@@ -908,24 +909,24 @@ public class VisualPatternPanel extends JPanel {
 		LG.i("Last chord duration: " + currentChordDuration);
 
 		double patternCoverage = currentChordDuration / Durations.WHOLE_NOTE;
-		if (chordSpan > 1 && patternCoverage > 1) {
-			/*while (chordSpan % 2 == 0 && patternRepeat % 2 == 0) {
+		/*if (chordSpan > 1 && patternRepeat != 3 && patternCoverage > 1 + MidiGenerator.DBL_ERR) {
+			while (chordSpan % 2 == 0 && patternRepeat % 2 == 0) {
 				chordSpan /= 2;
 				patternRepeat /= 2;
-			}*/
-
+			}
+		}*/
+		if (chordSpan > 1 && patternRepeat > 1 && patternCoverage > 1 + MidiGenerator.DBL_ERR) {
 			int chordSpanPart = chordNumInMeasure % chordSpan;
-			// part -> which part of pattern to use
-
 			double normalizedPercentage = percentage / patternCoverage;
-			//normalizedPercentage /= patternRepeat;
+			// percentage within a chord part
 			normalizedPercentage -= (chordSpan == 4) ? SPAN_4_ZONES[chordSpanPart]
 					: SPAN_2_ZONES[chordSpanPart];
-			LG.i("Percentage norm: " + normalizedPercentage);
+			LG.i("Percentage norm (current chord): " + normalizedPercentage);
+
+			double repeatThreshold = (chordSpan == 4) ? 0.25 : 0.5;
 			double newPercentage = normalizedPercentage % patternCoverage;
 			//newPercentage %= 1.0;
 			newPercentage *= patternCoverage;
-			double repeatThreshold = (chordSpan == 4) ? 0.25 : 0.5;
 			newPercentage %= repeatThreshold;
 			newPercentage += (chordSpan == 4) ? SPAN_4_ZONES[chordSpanPart]
 					: SPAN_2_ZONES[chordSpanPart];
@@ -934,9 +935,9 @@ public class VisualPatternPanel extends JPanel {
 			//int leftover = (int) Math.floor((percentage % wholeNotesInMeasure) / zoneCalc);
 			//percentage = (percentage - (leftover * zoneCalc))
 			//		+ ((chordSpan == 4) ? SPAN_4_ZONES[leftover] : SPAN_2_ZONES[leftover]);
-		} else {
-			percentage *= patternRepeat;
 		}
+
+		percentage *= patternRepeat;
 		// 10 for modulo calc
 		percentage = (10.0 + percentage) % 1.0;
 		LG.i("Percentage: " + percentage);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
@@ -32,6 +32,7 @@ import javax.swing.event.DocumentListener;
 
 import org.vibehistorian.vibecomposer.MidiGenerator.Durations;
 import org.vibehistorian.vibecomposer.MidiUtils;
+import org.vibehistorian.vibecomposer.OMNI;
 import org.vibehistorian.vibecomposer.VibeComposerGUI;
 import org.vibehistorian.vibecomposer.Components.ColorCheckBox;
 import org.vibehistorian.vibecomposer.Components.ScrollComboBox;
@@ -423,12 +424,26 @@ public class VisualPatternPanel extends JPanel {
 	protected void randomizePattern() {
 		//LG.i("Randomize pattern.");
 		if (patternType.isEnabled()) {
-			patternType.setValRaw(RhythmPattern.CUSTOM);
-			shiftPanel.setInt(0);
 			Random rand = new Random();
-			for (int i = 0; i < MAX_HITS; i++) {
-				truePattern.set(i, rand.nextInt(2));
+			if (RhythmPattern.EUCLID.equals(patternType.getVal())) {
+				long oldNum = truePattern.subList(0, lastHits).stream().filter(e -> e > 0).count();
+				int newNum = rand.nextInt((lastHits / 2) + 1) + (lastHits / 4) + 1;
+				if (newNum == oldNum) {
+					if (newNum == lastHits) {
+						newNum--;
+					} else {
+						newNum++;
+					}
+				}
+				newNum = OMNI.clamp(newNum, 1, lastHits);
+				truePattern = RhythmPattern.makeEuclideanPattern(lastHits, newNum, 0, MAX_HITS);
+			} else {
+				patternType.setValRaw(RhythmPattern.CUSTOM);
+				for (int i = 0; i < MAX_HITS; i++) {
+					truePattern.set(i, rand.nextInt(2));
+				}
 			}
+			shiftPanel.setInt(0);
 			reapplyShift();
 		}
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
@@ -413,8 +413,10 @@ public class VisualPatternPanel extends JPanel {
 		}
 		List<InstPanel> allPanels = VibeComposerGUI.getAffectedPanels(instParent.getPartNum());
 		allPanels.forEach(e -> {
-			e.getComboPanel().randomizePattern();
-			e.getComboPanel().repaint();
+			if (e.getComboPanel().patternType.isEnabled()) {
+				e.getComboPanel().randomizePattern();
+				e.getComboPanel().repaint();
+			}
 		});
 	}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
@@ -834,7 +834,7 @@ public class VisualPatternPanel extends JPanel {
 
 		VisualPatternPanel.this.setPreferredSize(new Dimension(width + bigModeWidthOffset, height));
 
-		parentPanel.setMaximumSize(new Dimension(3000, height > 50 ? height + 20 : 50));
+		parentPanel.setMaximumSize(new Dimension(3000, height > 50 ? height + 6 : 50));
 		repaint();
 	}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
@@ -895,10 +895,7 @@ public class VisualPatternPanel extends JPanel {
 		// chordSpan = 2 --> subtract pairs/triples/quadruples
 		int chordSpan = chordSpanPanel.getInt();
 		int patternRepeat = parentPanel.getPatternRepeat();
-		while (chordSpan % 2 == 0 && patternRepeat % 2 == 0) {
-			chordSpan /= 2;
-			patternRepeat /= 2;
-		}
+
 		int indexOfSubtractableDurations = chordSpan * ((chordNumInMeasure) / chordSpan);
 		for (int i = 0; i < indexOfSubtractableDurations; i++) {
 			currentPatternTime -= prevChordDurations.get(i);
@@ -907,18 +904,19 @@ public class VisualPatternPanel extends JPanel {
 
 		double patternTotalDuration = Durations.WHOLE_NOTE * chordSpan;
 		double percentage = (currentPatternTime / patternTotalDuration);
-
-		if (patternRepeat > 1 && chordSpan == 1) {
-			percentage *= patternRepeat;
-		}
 		LG.i("Percentage raw: " + percentage);
 		LG.i("Last chord duration: " + currentChordDuration);
 
-		if (chordSpan > 1) {
+		double patternCoverage = currentChordDuration / Durations.WHOLE_NOTE;
+		if (chordSpan > 1 && patternCoverage > 1) {
+			/*while (chordSpan % 2 == 0 && patternRepeat % 2 == 0) {
+				chordSpan /= 2;
+				patternRepeat /= 2;
+			}*/
+
 			int chordSpanPart = chordNumInMeasure % chordSpan;
 			// part -> which part of pattern to use
 
-			double patternCoverage = currentChordDuration / Durations.WHOLE_NOTE;
 			double normalizedPercentage = percentage / patternCoverage;
 			//normalizedPercentage /= patternRepeat;
 			normalizedPercentage -= (chordSpan == 4) ? SPAN_4_ZONES[chordSpanPart]
@@ -936,6 +934,8 @@ public class VisualPatternPanel extends JPanel {
 			//int leftover = (int) Math.floor((percentage % wholeNotesInMeasure) / zoneCalc);
 			//percentage = (percentage - (leftover * zoneCalc))
 			//		+ ((chordSpan == 4) ? SPAN_4_ZONES[leftover] : SPAN_2_ZONES[leftover]);
+		} else {
+			percentage *= patternRepeat;
 		}
 		// 10 for modulo calc
 		percentage = (10.0 + percentage) % 1.0;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Panels/VisualPatternPanel.java
@@ -464,13 +464,70 @@ public class VisualPatternPanel extends JPanel {
 					}
 					reapplyShift();
 					if (lastHits != 24 && lastHits != 10) {
-						hitsPanel.getKnob().setValue(2 * lastHits);
+						hitsPanel.setInt(2 * lastHits);
 					}
 
 
 				}
 			});
 		}
+	}
+
+	public void linkExpander(JButton expander) {
+		if (expander != null) {
+			expander.addMouseListener(new MouseAdapter() {
+
+				@Override
+				public void mouseReleased(MouseEvent e) {
+					if (e.isControlDown()) {
+						expand2xGlobal();
+					} else {
+						expand2x();
+					}
+				}
+			});
+		}
+	}
+
+	public void expand2xGlobal() {
+		InstPanel instParent = parentPanel;
+		if (instParent == null) {
+			expand2x();
+			repaint();
+			return;
+		}
+		List<InstPanel> allPanels = VibeComposerGUI.getAffectedPanels(instParent.getPartNum());
+		allPanels.forEach(e -> {
+			if (e.getComboPanel().hitsPanel.isEnabled()) {
+				e.getComboPanel().expand2x();
+				e.getComboPanel().repaint();
+			}
+		});
+	}
+
+	public void expand2x() {
+		List<Integer> tickThresholds = hitsPanel.getKnob().getTickThresholds();
+		if (!hitsPanel.isEnabled() || !chordSpanPanel.isEnabled() || chordSpanPanel.getInt() > 2
+				|| !(tickThresholds.contains(lastHits * 2))) {
+			return;
+		}
+		List<Integer> firstPattern = truePattern.subList(0, lastHits);
+		Collections.rotate(firstPattern, shiftPanel.getInt());
+		for (int i = 0; i < lastHits; i++) {
+			firstPattern.add(0);
+		}
+		truePattern = firstPattern;
+		while (truePattern.size() < MAX_HITS) {
+			truePattern.addAll(firstPattern);
+		}
+		truePattern = truePattern.subList(0, MAX_HITS);
+		if (shiftPanel.getInt() > 0) {
+			shiftPanel.setInt(0);
+		}
+		patternType.setVal(RhythmPattern.CUSTOM);
+		hitsPanel.setInt(lastHits * 2);
+		chordSpanPanel.setInt(chordSpanPanel.getInt() * 2);
+		reapplyShift();
 	}
 
 	public void linkVelocityToggle(JButton veloToggler) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Parts/ArpPart.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Parts/ArpPart.java
@@ -15,6 +15,7 @@ public class ArpPart extends InstPart {
 	private int arpPatternRotate = 0;
 	private List<Integer> arpPatternCustom = null;
 	private List<Integer> arpContour = null;
+	private boolean arpContourChordMode = false;
 
 	public ArpPart() {
 		partNum = 3;
@@ -60,5 +61,15 @@ public class ArpPart extends InstPart {
 
 	public void setArpContour(List<Integer> arpContour) {
 		this.arpContour = arpContour;
+	}
+
+
+	public boolean isArpContourChordMode() {
+		return arpContourChordMode;
+	}
+
+
+	public void setArpContourChordMode(boolean arpContourChordMode) {
+		this.arpContourChordMode = arpContourChordMode;
 	};
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Parts/ArpPart.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Parts/ArpPart.java
@@ -14,6 +14,7 @@ public class ArpPart extends InstPart {
 	private ArpPattern arpPattern = ArpPattern.RANDOM;
 	private int arpPatternRotate = 0;
 	private List<Integer> arpPatternCustom = null;
+	private List<Integer> arpContour = null;
 
 	public ArpPart() {
 		partNum = 3;
@@ -49,5 +50,15 @@ public class ArpPart extends InstPart {
 
 	public void setArpPatternCustom(List<Integer> arpPatternCustom) {
 		this.arpPatternCustom = arpPatternCustom;
+	}
+
+
+	public List<Integer> getArpContour() {
+		return arpContour;
+	}
+
+
+	public void setArpContour(List<Integer> arpContour) {
+		this.arpContour = arpContour;
 	};
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Parts/Defaults/DrumSettings.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Parts/Defaults/DrumSettings.java
@@ -17,7 +17,7 @@ public class DrumSettings {
 		COOL_16_PATTERNS.add(
 				Arrays.asList(new Integer[] { 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 }));
 		COOL_16_PATTERNS.add(
-				Arrays.asList(new Integer[] { 1, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0 }));
+				Arrays.asList(new Integer[] { 1, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0 }));
 		COOL_16_PATTERNS.add(
 				Arrays.asList(new Integer[] { 1, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0 }));
 		COOL_16_PATTERNS.add(

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Parts/InstPart.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Parts/InstPart.java
@@ -51,8 +51,8 @@ public abstract class InstPart implements Cloneable {
 	protected int offset = 0;
 	protected int transpose = 0;
 	protected int feedbackCount = 0;
-	protected int feedbackDuration = 500;
-	protected int feedbackVol = 80;
+	protected int feedbackDuration = 750;
+	protected int feedbackVol = 65;
 
 	protected int velocityMin = 69;
 	protected int velocityMax = 90;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Parts/MelodyPart.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Parts/MelodyPart.java
@@ -22,6 +22,7 @@ public class MelodyPart extends InstPart {
 	private int noteExceptionChance = 33;
 	private int speed = 0;
 	private int startNoteChance = 100;
+	private boolean patternFlexible = false;
 
 	public MelodyPart() {
 		partNum = 0;
@@ -133,5 +134,13 @@ public class MelodyPart extends InstPart {
 
 	public void setStartNoteChance(int startNoteChance) {
 		this.startNoteChance = startNoteChance;
+	}
+
+	public boolean isPatternFlexible() {
+		return patternFlexible;
+	}
+
+	public void setPatternFlexible(boolean patternFlexible) {
+		this.patternFlexible = patternFlexible;
 	};
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/AboutPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/AboutPopup.java
@@ -22,7 +22,7 @@ public class AboutPopup extends CloseablePopup {
 		textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
 		scroll = new JScrollPane(textArea, JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
 				JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS);
-		textArea.append("Copyright \u00a9 Vibe Historian 2021");
+		textArea.append("Copyright \u00a9 Vibe Historian 2023");
 		textArea.append("" + "\r\n"
 				+ "This program is free software; you can redistribute it and/or modify\r\n"
 				+ "it under the terms of the GNU General Public License as published by\r\n"

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ButtonIntegerListValuePopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ButtonIntegerListValuePopup.java
@@ -57,14 +57,17 @@ public class ButtonIntegerListValuePopup extends CloseablePopup {
 
 			@Override
 			public void windowClosing(WindowEvent e) {
-				try {
-					customInput = intListField.getText();
-				} catch (NumberFormatException ex) {
-					LG.d("Invalid value: " + intListField.getText());
+				if (frame.isVisible()) {
+					try {
+						customInput = intListField.getText();
+					} catch (NumberFormatException ex) {
+						LG.d("Invalid value: " + intListField.getText());
+					}
+					if (customInput != null) {
+						butt.setValue(customInput);
+					}
 				}
-				if (customInput != null) {
-					butt.setValue(customInput);
-				}
+
 
 				/*if (RandomValueButton.singlePopup != null) {
 					if (RandomValueButton.singlePopup.randomNum == randomNum) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ButtonValuePopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ButtonValuePopup.java
@@ -65,14 +65,17 @@ public class ButtonValuePopup extends CloseablePopup {
 
 			@Override
 			public void windowClosing(WindowEvent e) {
-				try {
-					customInput = Integer.valueOf(numPanel.getTextfield().getText());
-				} catch (NumberFormatException ex) {
-					LG.d("Invalid value: " + numPanel.getTextfield().getText());
+				if (frame.isVisible()) {
+					try {
+						customInput = Integer.valueOf(numPanel.getTextfield().getText());
+					} catch (NumberFormatException ex) {
+						LG.d("Invalid value: " + numPanel.getTextfield().getText());
+					}
+					if (customInput != null) {
+						butt.setValue(customInput);
+					}
 				}
-				if (customInput != null) {
-					butt.setValue(customInput);
-				}
+
 
 				/*if (RandomValueButton.singlePopup != null) {
 					if (RandomValueButton.singlePopup.randomNum == randomNum) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ChordTransformPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ChordTransformPopup.java
@@ -1,0 +1,84 @@
+package org.vibehistorian.vibecomposer.Popups;
+
+import java.awt.Dimension;
+import java.awt.GridLayout;
+import java.awt.Point;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+import org.vibehistorian.vibecomposer.MidiUtils;
+import org.vibehistorian.vibecomposer.MidiUtils.ScaleMode;
+import org.vibehistorian.vibecomposer.VibeComposerGUI;
+import org.vibehistorian.vibecomposer.Components.Chordlet;
+import org.vibehistorian.vibecomposer.Components.ScrollComboBox;
+import org.vibehistorian.vibecomposer.Panels.ChordletPanel;
+
+public class ChordTransformPopup extends CloseablePopup {
+	private ScrollComboBox<String> scaleMode = new ScrollComboBox<>(false);
+	private ChordletPanel userChords = null;
+
+	public ChordTransformPopup(String chords) {
+		super("Transform Chords", 0, new Point(-600, -200));
+
+		JPanel allPanel = new JPanel();
+		allPanel.setLayout(new GridLayout(0, 2, 0, 0));
+		allPanel.setPreferredSize(new Dimension(700, 100));
+		String[] scaleModes = new String[MidiUtils.ScaleMode.values().length];
+		for (int i = 0; i < MidiUtils.ScaleMode.values().length; i++) {
+			scaleModes[i] = MidiUtils.ScaleMode.values()[i].toString();
+		}
+		ScrollComboBox.addAll(scaleModes, scaleMode);
+
+		userChords = new ChordletPanel(350, chords);
+		allPanel.add(userChords);
+		JPanel modePanel = new JPanel();
+		modePanel.add(new JLabel("Mode"));
+		modePanel.add(scaleMode);
+		allPanel.add(modePanel);
+
+		allPanel.add(VibeComposerGUI.makeButton("From Ionian To Mode", e -> {
+			convertFromIonian();
+		}));
+		allPanel.add(VibeComposerGUI.makeButton("From Mode To Ionian", e -> {
+			convertToIonian();
+		}));
+		frame.add(allPanel);
+		frame.pack();
+		frame.setVisible(true);
+	}
+
+	private void convertFromIonian() {
+		List<Chordlet> chordlets = userChords.getChordlets();
+		List<String> newModeChords = new ArrayList<>();
+		chordlets.forEach(ch -> {
+			newModeChords.add(MidiUtils.chordStringFromPitches(
+					MidiUtils.transposeChord(MidiUtils.mappedChord(ch.getChordText(), true),
+							ScaleMode.IONIAN.noteAdjustScale,
+							ScaleMode.valueOf(scaleMode.getVal()).noteAdjustScale, true))
+					+ ch.getInversionText());
+		});
+		userChords.setupChords(newModeChords);
+	}
+
+	private void convertToIonian() {
+		List<Chordlet> chordlets = userChords.getChordlets();
+		List<String> newModeChords = new ArrayList<>();
+		chordlets.forEach(ch -> {
+			newModeChords.add(MidiUtils.chordStringFromPitches(
+					MidiUtils.transposeChord(MidiUtils.mappedChord(ch.getChordText(), true),
+							ScaleMode.valueOf(scaleMode.getVal()).noteAdjustScale,
+							ScaleMode.IONIAN.noteAdjustScale, true))
+					+ ch.getInversionText());
+		});
+		userChords.setupChords(newModeChords);
+	}
+
+	@Override
+	protected void addFrameWindowOperation() {
+		frame.addWindowListener(EMPTY_WINDOW_LISTENER);
+	}
+
+}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ChordTransformPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ChordTransformPopup.java
@@ -15,9 +15,12 @@ import org.vibehistorian.vibecomposer.VibeComposerGUI;
 import org.vibehistorian.vibecomposer.Components.Chordlet;
 import org.vibehistorian.vibecomposer.Components.ScrollComboBox;
 import org.vibehistorian.vibecomposer.Panels.ChordletPanel;
+import org.vibehistorian.vibecomposer.Panels.DetachedKnobPanel;
+import org.vibehistorian.vibecomposer.Panels.KnobPanel;
 
 public class ChordTransformPopup extends CloseablePopup {
 	private ScrollComboBox<String> scaleMode = new ScrollComboBox<>(false);
+	private KnobPanel transpose = new DetachedKnobPanel("Transpose By", 0, -12, 12);
 	private ChordletPanel userChords = null;
 
 	public ChordTransformPopup(String chords) {
@@ -37,6 +40,10 @@ public class ChordTransformPopup extends CloseablePopup {
 		JPanel modePanel = new JPanel();
 		modePanel.add(new JLabel("Mode"));
 		modePanel.add(scaleMode);
+		modePanel.add(transpose);
+		modePanel.add(VibeComposerGUI.makeButton("R", e -> {
+			transpose.setInt(-1 * transpose.getInt());
+		}));
 		allPanel.add(modePanel);
 
 		allPanel.add(VibeComposerGUI.makeButton("From Ionian To Mode", e -> {
@@ -54,11 +61,13 @@ public class ChordTransformPopup extends CloseablePopup {
 		List<Chordlet> chordlets = userChords.getChordlets();
 		List<String> newModeChords = new ArrayList<>();
 		chordlets.forEach(ch -> {
-			newModeChords.add(MidiUtils.chordStringFromPitches(
-					MidiUtils.transposeChord(MidiUtils.mappedChord(ch.getChordText(), true),
-							ScaleMode.IONIAN.noteAdjustScale,
-							ScaleMode.valueOf(scaleMode.getVal()).noteAdjustScale, true))
-					+ ch.getInversionText());
+			int[] pitches = MidiUtils.transposeChord(MidiUtils.mappedChord(ch.getChordText(), true),
+					ScaleMode.IONIAN.noteAdjustScale,
+					ScaleMode.valueOf(scaleMode.getVal()).noteAdjustScale, true);
+			if (transpose.getInt() != 0) {
+				pitches = MidiUtils.transposeChord(pitches, transpose.getInt());
+			}
+			newModeChords.add(MidiUtils.chordStringFromPitches(pitches) + ch.getInversionText());
 		});
 		userChords.setupChords(newModeChords);
 	}
@@ -67,11 +76,14 @@ public class ChordTransformPopup extends CloseablePopup {
 		List<Chordlet> chordlets = userChords.getChordlets();
 		List<String> newModeChords = new ArrayList<>();
 		chordlets.forEach(ch -> {
-			newModeChords.add(MidiUtils.chordStringFromPitches(
-					MidiUtils.transposeChord(MidiUtils.mappedChord(ch.getChordText(), true),
-							ScaleMode.valueOf(scaleMode.getVal()).noteAdjustScale,
-							ScaleMode.IONIAN.noteAdjustScale, true))
-					+ ch.getInversionText());
+			int[] pitches = MidiUtils.mappedChord(ch.getChordText(), true);
+			if (transpose.getInt() != 0) {
+				pitches = MidiUtils.transposeChord(pitches, transpose.getInt());
+			}
+			pitches = MidiUtils.transposeChord(pitches,
+					ScaleMode.valueOf(scaleMode.getVal()).noteAdjustScale,
+					ScaleMode.IONIAN.noteAdjustScale, true);
+			newModeChords.add(MidiUtils.chordStringFromPitches(pitches) + ch.getInversionText());
 		});
 		userChords.setupChords(newModeChords);
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/CloseablePopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/CloseablePopup.java
@@ -76,6 +76,7 @@ public abstract class CloseablePopup {
 	public void close() {
 		Toolkit.getDefaultToolkit().getSystemEventQueue()
 				.postEvent(new WindowEvent(frame, WindowEvent.WINDOW_CLOSING));
+		handleClose();
 
 	}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/CloseablePopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/CloseablePopup.java
@@ -1,6 +1,5 @@
 package org.vibehistorian.vibecomposer.Popups;
 
-import java.awt.MouseInfo;
 import java.awt.Point;
 import java.awt.Toolkit;
 import java.awt.event.WindowEvent;
@@ -9,6 +8,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.swing.JFrame;
+
+import org.vibehistorian.vibecomposer.SwingUtils;
 
 public abstract class CloseablePopup {
 	final JFrame frame = new JFrame();
@@ -51,10 +52,12 @@ public abstract class CloseablePopup {
 
 	public CloseablePopup(String windowTitle, Integer popupType, Point locOffset) {
 		this.setPopupType(popupType);
-		Point loc = MouseInfo.getPointerInfo().getLocation();
+		Point loc = SwingUtils.getMouseLocation();
 		loc.translate(12, 12);
 		loc.translate(locOffset.x, locOffset.y);
-		frame.setLocation(loc);
+		SwingUtils.setFrameLocation(frame, loc);
+
+		//frame.setLocation(-500, 50);
 		addFrameWindowOperation();
 		frame.setTitle(windowTitle);
 		handleOpen();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/DrumLoopPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/DrumLoopPopup.java
@@ -1,7 +1,6 @@
 package org.vibehistorian.vibecomposer.Popups;
 
 import java.awt.Dimension;
-import java.awt.MouseInfo;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -15,6 +14,7 @@ import javax.swing.JSlider;
 import javax.swing.JTextField;
 
 import org.vibehistorian.vibecomposer.LG;
+import org.vibehistorian.vibecomposer.SwingUtils;
 import org.vibehistorian.vibecomposer.VibeComposerGUI;
 import org.vibehistorian.vibecomposer.Helpers.CheckBoxIcon;
 import org.vibehistorian.vibecomposer.Panels.DrumPanel;
@@ -63,7 +63,7 @@ public class DrumLoopPopup {
 				JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS);
 
 		scroll.getVerticalScrollBar().setUnitIncrement(16);
-		frame.setLocation(MouseInfo.getPointerInfo().getLocation());
+		frame.setLocation(SwingUtils.getMouseLocation());
 		frame.add(scroll);
 		frame.pack();
 		frame.setVisible(true);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/KnobValuePopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/KnobValuePopup.java
@@ -59,9 +59,6 @@ public class KnobValuePopup extends CloseablePopup {
 
 	@Override
 	public void close() {
-		if (VibeComposerGUI.canRegenerateOnChange() && frame.isVisible() && regenerating) {
-			VibeComposerGUI.vibeComposerGUI.regenerate();
-		}
 		super.close();
 	}
 
@@ -99,6 +96,10 @@ public class KnobValuePopup extends CloseablePopup {
 								knob.setValue(OMNI.clamp(val, knob.getMin(), knob.getMax()));
 							}
 							knob.repaint();
+						}
+
+						if (VibeComposerGUI.canRegenerateOnChange() && regenerating) {
+							VibeComposerGUI.vibeComposerGUI.regenerate();
 						}
 
 					}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/KnobValuePopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/KnobValuePopup.java
@@ -59,7 +59,7 @@ public class KnobValuePopup extends CloseablePopup {
 
 	@Override
 	public void close() {
-		if (VibeComposerGUI.canRegenerateOnChange() && regenerating) {
+		if (VibeComposerGUI.canRegenerateOnChange() && frame.isVisible() && regenerating) {
 			VibeComposerGUI.vibeComposerGUI.regenerate();
 		}
 		super.close();
@@ -76,30 +76,32 @@ public class KnobValuePopup extends CloseablePopup {
 
 			@Override
 			public void windowClosing(WindowEvent e) {
-				try {
-					customInput = Integer.valueOf(numPanel.getTextfield().getText());
-				} catch (NumberFormatException ex) {
-					LG.d("Invalid value: " + numPanel.getTextfield().getText());
-				}
-				if (customInput != null) {
-					int val = customInput;
-					if (stretchAfterCustomInput) {
-						if (val > knob.getMax()) {
-							knob.setMax(val);
-						} else if (val < knob.getMin()) {
-							knob.setMin(val);
-						}
-						knob.setValue(val);
-						knob.repaint();
-					} else {
-						if (knob.getMin() <= val && knob.getMax() >= val) {
-							knob.setValue(val);
-						} else {
-							knob.setValue(OMNI.clamp(val, knob.getMin(), knob.getMax()));
-						}
-						knob.repaint();
+				if (frame.isVisible()) {
+					try {
+						customInput = Integer.valueOf(numPanel.getTextfield().getText());
+					} catch (NumberFormatException ex) {
+						LG.d("Invalid value: " + numPanel.getTextfield().getText());
 					}
+					if (customInput != null) {
+						int val = customInput;
+						if (stretchAfterCustomInput) {
+							if (val > knob.getMax()) {
+								knob.setMax(val);
+							} else if (val < knob.getMin()) {
+								knob.setMin(val);
+							}
+							knob.setValue(val);
+							knob.repaint();
+						} else {
+							if (knob.getMin() <= val && knob.getMax() >= val) {
+								knob.setValue(val);
+							} else {
+								knob.setValue(OMNI.clamp(val, knob.getMin(), knob.getMax()));
+							}
+							knob.repaint();
+						}
 
+					}
 				}
 
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
@@ -59,7 +59,6 @@ import org.vibehistorian.vibecomposer.Parts.ChordPart;
 import org.vibehistorian.vibecomposer.Parts.DrumPart;
 import org.vibehistorian.vibecomposer.Parts.InstPart;
 import org.vibehistorian.vibecomposer.Parts.MelodyPart;
-import org.vibehistorian.vibecomposer.Popups.MidiEditPopup.PatternNameMarker;
 
 import jm.music.data.Note;
 import jm.music.data.Part;
@@ -74,6 +73,7 @@ public class MidiEditPopup extends CloseablePopup {
 	public static boolean regenerateInPlaceChoice = false;
 	public static boolean applyOnLoadChoice = false;
 	public static boolean loadOnSelectChoice = false;
+	public static boolean displayingPhraseMarginX = false;
 
 	public static final int baseMargin = 5;
 	public static int trackScope = 1;
@@ -92,6 +92,7 @@ public class MidiEditPopup extends CloseablePopup {
 	public CheckButton applyOnLoad = new CheckButton("Apply on Load/Import", applyOnLoadChoice);
 	public CheckButton loadOnSelect = new CheckButton("Load on Select", loadOnSelectChoice);
 	public CheckButton snapToScaleGrid = new CheckButton("Snap to Scale", snapToGridChoice);
+	public CheckButton displayPhraseMargins = new CheckButton("Margins", displayingPhraseMarginX);
 
 	public ScrollComboBox<String> patternPartBox = new ScrollComboBox<>(false);
 	public ScrollComboBox<Integer> patternPartOrderBox = new ScrollComboBox<>(false);
@@ -392,6 +393,10 @@ public class MidiEditPopup extends CloseablePopup {
 		displayDrumHelper.setFunc(e -> {
 			repaintMvea();
 		});
+		displayPhraseMargins.setFunc(e -> {
+			displayingPhraseMarginX = displayPhraseMargins.isSelected();
+			repaintMvea();
+		});
 
 		patternNameBox.setFunc(e -> {
 			if (loadOnSelectChoice) {
@@ -403,6 +408,7 @@ public class MidiEditPopup extends CloseablePopup {
 		bottomSettingsPanel.add(applyOnLoad);
 		bottomSettingsPanel.add(regenerateInPlaceOnChange);
 		bottomSettingsPanel.add(displayDrumHelper);
+		bottomSettingsPanel.add(displayPhraseMargins);
 		bottomSettingsPanel.add(new JLabel("  Highlight Mode:"));
 		bottomSettingsPanel.add(highlightMode);
 		bottomSettingsPanel.add(new JLabel("  Snap To Time:"));

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
@@ -157,6 +157,16 @@ public class MidiEditPopup extends CloseablePopup {
 
 		setCustomValues(values);
 
+		values.remakeNoteStartTimes();
+
+		for (PhraseNote pn : values) {
+			if (pn.getStartTime() < 0) {
+				displayingPhraseMarginX = true;
+			} else if (pn.getStartTime() + pn.getDuration() > MidiEditArea.sectionLength) {
+				displayingPhraseMarginX = true;
+			}
+		}
+		displayPhraseMargins.setSelected(displayingPhraseMarginX);
 
 		allPanels.add(buttonPanel);
 		allPanels.add(buttonPanel2);
@@ -393,6 +403,7 @@ public class MidiEditPopup extends CloseablePopup {
 		displayDrumHelper.setFunc(e -> {
 			repaintMvea();
 		});
+
 		displayPhraseMargins.setFunc(e -> {
 			displayingPhraseMarginX = displayPhraseMargins.isSelected();
 			repaintMvea();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
@@ -42,6 +42,7 @@ import org.vibehistorian.vibecomposer.MidiUtils;
 import org.vibehistorian.vibecomposer.MidiUtils.ScaleMode;
 import org.vibehistorian.vibecomposer.OMNI;
 import org.vibehistorian.vibecomposer.Section;
+import org.vibehistorian.vibecomposer.SwingUtils;
 import org.vibehistorian.vibecomposer.VibeComposerGUI;
 import org.vibehistorian.vibecomposer.Components.CheckButton;
 import org.vibehistorian.vibecomposer.Components.MidiDropPane;
@@ -177,7 +178,7 @@ public class MidiEditPopup extends CloseablePopup {
 
 		addKeyboardControls(allPanels);
 
-		frame.setLocation(VibeComposerGUI.vibeComposerGUI.getLocation());
+		SwingUtils.setFrameLocation(frame, VibeComposerGUI.vibeComposerGUI.getLocation());
 		frame.add(allPanels);
 		frame.pack();
 		frame.setVisible(true);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/MidiEditPopup.java
@@ -59,6 +59,7 @@ import org.vibehistorian.vibecomposer.Parts.ChordPart;
 import org.vibehistorian.vibecomposer.Parts.DrumPart;
 import org.vibehistorian.vibecomposer.Parts.InstPart;
 import org.vibehistorian.vibecomposer.Parts.MelodyPart;
+import org.vibehistorian.vibecomposer.Popups.MidiEditPopup.PatternNameMarker;
 
 import jm.music.data.Note;
 import jm.music.data.Part;
@@ -462,7 +463,7 @@ public class MidiEditPopup extends CloseablePopup {
 					if (SwingUtilities.isLeftMouseButton(e)) {
 						saveNotes(true);
 					} else {
-						new PatternNamePopup(patternName -> {
+						new TextProcessingPopup("Pattern - New", patternName -> {
 							PatternNameMarker pnm = new PatternNameMarker(patternName, true);
 							patternNameBox.addItem(pnm);
 							patternNameBox.setVal(pnm);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/PatternManagerPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/PatternManagerPopup.java
@@ -2,6 +2,7 @@ package org.vibehistorian.vibecomposer.Popups;
 
 import java.awt.Dimension;
 import java.awt.GridLayout;
+import java.awt.Point;
 import java.util.IntSummaryStatistics;
 import java.util.List;
 import java.util.Set;
@@ -33,7 +34,7 @@ public class PatternManagerPopup extends CloseablePopup {
 	CustomCheckBox removeCB = new CustomCheckBox("Remove", false);
 
 	public PatternManagerPopup() {
-		super("Pattern Manager", 14);
+		super("Pattern Manager", 14, new Point(-2000, -2000));
 
 		JPanel allPanels = new JPanel();
 		allPanels.setLayout(new BoxLayout(allPanels, BoxLayout.Y_AXIS));
@@ -113,7 +114,6 @@ public class PatternManagerPopup extends CloseablePopup {
 		allPanels.add(mveaPanel);
 		frame.add(allPanels);
 
-		frame.setLocation(VibeComposerGUI.vibeComposerGUI.getLocation());
 		frame.pack();
 		frame.setVisible(true);
 		LG.d("Opened Pattern Manager popup!");

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/PatternNamePopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/PatternNamePopup.java
@@ -57,7 +57,9 @@ public class PatternNamePopup extends CloseablePopup {
 
 			@Override
 			public void windowClosing(WindowEvent e) {
-				callback.accept(textField.getText());
+				if (frame.isVisible()) {
+					callback.accept(textField.getText());
+				}
 			}
 
 			@Override

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ShowScorePopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ShowScorePopup.java
@@ -27,12 +27,14 @@ public class ShowScorePopup extends CloseablePopup {
 
 			@Override
 			public void windowClosing(WindowEvent e) {
-				frame.remove(VibeComposerGUI.scoreScrollPane);
-				currentPopupMap.remove(12);
-				VibeComposerGUI.instrumentTabPane.add(VibeComposerGUI.scoreScrollPane, 7);
-				VibeComposerGUI.instrumentTabPane.setTitleAt(7, " Score ");
-				VibeComposerGUI.scorePopup = null;
-				frame.dispose();
+				if (frame.isVisible()) {
+					frame.remove(VibeComposerGUI.scoreScrollPane);
+					currentPopupMap.remove(12);
+					VibeComposerGUI.instrumentTabPane.add(VibeComposerGUI.scoreScrollPane, 7);
+					VibeComposerGUI.instrumentTabPane.setTitleAt(7, " Score ");
+					VibeComposerGUI.scorePopup = null;
+					frame.dispose();
+				}
 			}
 
 			@Override

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ShowScorePopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ShowScorePopup.java
@@ -42,6 +42,7 @@ public class ShowScorePopup extends CloseablePopup {
 					VibeComposerGUI.instrumentTabPane.setTitleAt(7, " Score ");
 					currentPopupMap.remove(12);
 					//if (VibeComposerGUI.miniScorePopup.isSelected()) {
+					ShowPanelBig.beatWidthBases = ShowPanelBig.beatWidthBasesBig;
 					ShowPanelBig.beatWidthBase = ShowPanelBig.beatWidthBases
 							.get(ShowPanelBig.beatWidthBaseIndex);
 					VibeComposerGUI.scorePanel

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ShowScorePopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/ShowScorePopup.java
@@ -1,21 +1,30 @@
 package org.vibehistorian.vibecomposer.Popups;
 
+import java.awt.Dimension;
+import java.awt.Point;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 
 import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
 
 import org.vibehistorian.vibecomposer.VibeComposerGUI;
+import org.vibehistorian.vibecomposer.Components.ShowPanelBig;
 
 public class ShowScorePopup extends CloseablePopup {
 
 	public ShowScorePopup(JScrollPane scoreScrollPane) {
-		super("MIDI Score", 12);
+		super("MIDI Score", 12, new Point(-400, -500));
 		frame.add(scoreScrollPane);
-		frame.setResizable(false);
+		if (VibeComposerGUI.miniScorePopup.isSelected()) {
+			frame.setPreferredSize(new Dimension(650, 325));
+			frame.setMaximumSize(new Dimension(650, 325));
+			frame.setResizable(true);
+		}
 		frame.pack();
 		frame.setVisible(true);
 	}
+
 
 	@Override
 	protected void addFrameWindowOperation() {
@@ -29,10 +38,23 @@ public class ShowScorePopup extends CloseablePopup {
 			public void windowClosing(WindowEvent e) {
 				if (frame.isVisible()) {
 					frame.remove(VibeComposerGUI.scoreScrollPane);
-					currentPopupMap.remove(12);
 					VibeComposerGUI.instrumentTabPane.add(VibeComposerGUI.scoreScrollPane, 7);
 					VibeComposerGUI.instrumentTabPane.setTitleAt(7, " Score ");
+					currentPopupMap.remove(12);
+					//if (VibeComposerGUI.miniScorePopup.isSelected()) {
+					ShowPanelBig.beatWidthBase = ShowPanelBig.beatWidthBases
+							.get(ShowPanelBig.beatWidthBaseIndex);
+					VibeComposerGUI.scorePanel
+							.updatePanelHeight(VibeComposerGUI.scrollPaneDimension.height);
+					VibeComposerGUI.scorePanel.getShowArea().setNoteHeight(7);
+					VibeComposerGUI.scorePanel.setScore();
+					VibeComposerGUI.scoreScrollPane.repaint();
 					VibeComposerGUI.scorePopup = null;
+					SwingUtilities.invokeLater(() -> {
+						ShowPanelBig.zoomIn(ShowPanelBig.areaScrollPane, new Point(0, 300), 0.0,
+								(7 / 5.0) - 1.0);
+					});
+					//}
 					frame.dispose();
 				}
 			}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/SliderPopupListener.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/SliderPopupListener.java
@@ -1,21 +1,6 @@
 package org.vibehistorian.vibecomposer.Popups;
 
-import java.awt.Dimension;
-import java.awt.Point;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JSlider;
-import javax.swing.SwingConstants;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
-
-import org.vibehistorian.vibecomposer.LG;
-
-public class SliderPopupListener extends MouseAdapter {
+/*public class SliderPopupListener extends MouseAdapter {
 	private JDialog toolTip = null;
 	private final JLabel label = new JLabel("", SwingConstants.CENTER);
 	private final Dimension size = new Dimension(30, 20);
@@ -94,4 +79,4 @@ public class SliderPopupListener extends MouseAdapter {
 		};
 		cycle.start();
 	}
-}
+}*/

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/TemporaryInfoPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/TemporaryInfoPopup.java
@@ -1,6 +1,5 @@
 package org.vibehistorian.vibecomposer.Popups;
 
-import java.awt.MouseInfo;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
@@ -10,6 +9,8 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.Timer;
 
+import org.vibehistorian.vibecomposer.LG;
+import org.vibehistorian.vibecomposer.SwingUtils;
 import org.vibehistorian.vibecomposer.VibeComposerGUI;
 
 public class TemporaryInfoPopup {
@@ -29,7 +30,8 @@ public class TemporaryInfoPopup {
 		JPanel panel = new JPanel();
 		panel.add(textLabel);
 
-		frame.setLocation(MouseInfo.getPointerInfo().getLocation());
+		LG.i(VibeComposerGUI.vibeComposerGUI.getLocation().toString());
+		SwingUtils.setFrameLocation(frame, SwingUtils.getMouseLocation());
 		if (hideWindowControls) {
 			frame.setUndecorated(hideWindowControls);
 		}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/TextProcessingPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/TextProcessingPopup.java
@@ -8,12 +8,12 @@ import java.util.function.Consumer;
 
 import javax.swing.JTextField;
 
-public class PatternNamePopup extends CloseablePopup {
+public class TextProcessingPopup extends CloseablePopup {
 	private Consumer<String> callback = null;
 	private JTextField textField = new JTextField("", 8);
 
-	public PatternNamePopup(Consumer<String> callback) {
-		super("Pattern - New", 0);
+	public TextProcessingPopup(String title, Consumer<String> callback) {
+		super(title, 0);
 		this.callback = callback;
 
 		textField.addKeyListener(new KeyListener() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/VariationPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/VariationPopup.java
@@ -35,6 +35,7 @@ import org.vibehistorian.vibecomposer.MidiUtils.ScaleMode;
 import org.vibehistorian.vibecomposer.OMNI;
 import org.vibehistorian.vibecomposer.Section;
 import org.vibehistorian.vibecomposer.SectionConfig;
+import org.vibehistorian.vibecomposer.SwingUtils;
 import org.vibehistorian.vibecomposer.VibeComposerGUI;
 import org.vibehistorian.vibecomposer.Components.CustomCheckBox;
 import org.vibehistorian.vibecomposer.Components.ScrollComboBox;
@@ -208,7 +209,7 @@ public class VariationPopup {
 		int heightLimit = 850;
 		frame.setPreferredSize(new Dimension(680, Math.min(parentDim.height, heightLimit)));
 		int newLocX = parentLoc.x - 190;
-		frame.setLocation((newLocX < 0) ? 0 : newLocX, parentLoc.y);
+		SwingUtils.setFrameLocation(frame, new Point(newLocX, parentLoc.y));
 		frame.add(scroll);
 		frame.setTitle("Variations - Section " + section);
 		frame.pack();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/VariationPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/VariationPopup.java
@@ -92,8 +92,7 @@ public class VariationPopup {
 					.collect(Collectors.toList());
 
 			table.setModel(new VariationsBooleanTableModel(fI, sectionOrder - 1,
-					sec.getPartMap().get(i), Section.variationDescriptions[i],
-					partNames));
+					sec.getPartMap().get(i), Section.variationDescriptions[i], partNames));
 			table.setRowSelectionAllowed(false);
 			table.setColumnSelectionAllowed(false);
 			table.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
@@ -207,7 +206,7 @@ public class VariationPopup {
 		scroll.getVerticalScrollBar().setUnitIncrement(16);
 		scroll.setAlignmentX(Component.LEFT_ALIGNMENT);
 		int heightLimit = 850;
-		frame.setPreferredSize(new Dimension(650, Math.min(parentDim.height, heightLimit)));
+		frame.setPreferredSize(new Dimension(680, Math.min(parentDim.height, heightLimit)));
 		int newLocX = parentLoc.x - 190;
 		frame.setLocation((newLocX < 0) ? 0 : newLocX, parentLoc.y);
 		frame.add(scroll);
@@ -272,13 +271,13 @@ public class VariationPopup {
 	private void addCustomChordsDurations(Section sec) {
 		JPanel customChordsDurationsPanel = new JPanel();
 		JCheckBox userChordsEnabled = new CustomCheckBox("Custom Chords",
-				sec.isCustomChordsDurationsEnabled());
+				sec.isCustomChordsEnabled());
 		customChordsDurationsPanel.add(userChordsEnabled);
 		userChordsEnabled.addItemListener(new ItemListener() {
 
 			@Override
 			public void itemStateChanged(ItemEvent e) {
-				sec.setCustomChordsDurationsEnabled(userChordsEnabled.isSelected());
+				sec.setCustomChordsEnabled(userChordsEnabled.isSelected());
 				VibeComposerGUI.recolorVariationPopupButton(sectionOrder);
 			}
 
@@ -291,16 +290,29 @@ public class VariationPopup {
 				? VibeComposerGUI.userChords.getChordListString()
 				: StringUtils.join(MidiGenerator.chordInts, ","));
 		userChords = new ChordletPanel(300,
-				(sec.isCustomChordsDurationsEnabled() || sec.isDisplayAlternateChords())
+				(sec.isCustomChordsEnabled() || sec.isDisplayAlternateChords())
 						? sec.getCustomChords()
 						: guiUserChords);
 		userChords.setToolTipText(tooltip);
 		customChordsDurationsPanel.add(userChords);
+
+
+		JCheckBox userDurationsEnabled = new CustomCheckBox("Custom Durations",
+				sec.isCustomDurationsEnabled());
+		customChordsDurationsPanel.add(userDurationsEnabled);
+		userDurationsEnabled.addItemListener(new ItemListener() {
+
+			@Override
+			public void itemStateChanged(ItemEvent e) {
+				sec.setCustomDurationsEnabled(userDurationsEnabled.isSelected());
+				VibeComposerGUI.recolorVariationPopupButton(sectionOrder);
+			}
+
+		});
 		userChordsDurations = new JTextField(
-				sec.isCustomChordsDurationsEnabled() ? sec.getCustomDurations()
+				sec.isCustomDurationsEnabled() ? sec.getCustomDurations()
 						: VibeComposerGUI.userChordsDurations.getText(),
 				7);
-		customChordsDurationsPanel.add(new JLabel("Chord durations:"));
 		customChordsDurationsPanel.add(userChordsDurations);
 		customChordsDurationsPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/VisualArrayPopup.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Popups/VisualArrayPopup.java
@@ -188,14 +188,16 @@ public class VisualArrayPopup extends CloseablePopup {
 
 			@Override
 			public void windowClosing(WindowEvent e) {
-				if (butt != null) {
-					butt.setValues(mvea.getValues());
+				if (frame.isVisible()) {
+					if (butt != null) {
+						butt.setValues(mvea.getValues());
+					}
+
+					if (closeFunc != null) {
+						closeFunc.accept(new Object());
+					}
 				}
 
-				if (closeFunc != null) {
-					closeFunc.accept(new Object());
-				}
-				handleClose();
 				/*if (RandomValueButton.singlePopup != null) {
 					if (RandomValueButton.singlePopup.randomNum == randomNum) {
 						RandomValueButton.singlePopup = null;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
@@ -354,7 +354,7 @@ public class Section {
 		sec.setArpParts(getArpParts());
 		sec.setDrumParts(getDrumParts());
 
-		sec.setPatterns(patterns);
+		sec.setPatterns(UsedPatternMap.multiMapCopy(patterns));
 
 		sec.setCustomChords(getCustomChords());
 		sec.setCustomDurations(getCustomDurations());

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
@@ -375,7 +375,11 @@ public class Section {
 	}
 
 	public void resetCustomizedParts(int partNum) {
-		setInstPartList(null, partNum);
+		if (partNum > 4) {
+			resetCustomizedParts();
+		} else {
+			setInstPartList(null, partNum);
+		}
 	}
 
 	public void resetCustomizedParts() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
@@ -923,6 +923,24 @@ public class Section {
 		return customDurations;
 	}
 
+	public List<Double> getCustomDurationsList() {
+		if (StringUtils.isEmpty(customDurations)) {
+			return null;
+		} else {
+			String[] durations = customDurations.split(",");
+			List<Double> durationsList = new ArrayList<>();
+			try {
+				for (String c : durations) {
+					durationsList.add(Double.parseDouble(c));
+				}
+			} catch (Exception ex) {
+				LG.e(">>>>Custom section durations have wrong (not double) values!");
+				return null;
+			}
+			return durationsList;
+		}
+	}
+
 	public void setCustomDurations(String customDurations) {
 		this.customDurations = customDurations;
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
@@ -105,7 +105,8 @@ public class Section {
 	private Phrase chordSlash;
 
 	// customized chords/durations
-	private boolean customChordsDurationsEnabled = false;
+	private boolean customChordsEnabled = false;
+	private boolean customDurationsEnabled = false;
 	private boolean displayAlternateChords = false;
 	private String customChords = "?";
 	private String customDurations = "4,4,4,4";
@@ -357,7 +358,7 @@ public class Section {
 
 		sec.setCustomChords(getCustomChords());
 		sec.setCustomDurations(getCustomDurations());
-		sec.setCustomChordsDurationsEnabled(customChordsDurationsEnabled);
+		sec.setCustomChordsEnabled(customChordsEnabled);
 		sec.setSectionDuration(sectionDuration);
 		sec.setDisplayAlternateChords(isDisplayAlternateChords());
 		if (sectionBeatDurations != null) {
@@ -925,12 +926,12 @@ public class Section {
 		this.customDurations = customDurations;
 	}
 
-	public boolean isCustomChordsDurationsEnabled() {
-		return customChordsDurationsEnabled;
+	public boolean isCustomChordsEnabled() {
+		return customChordsEnabled;
 	}
 
-	public void setCustomChordsDurationsEnabled(boolean customChordsDurationsEnabled) {
-		this.customChordsDurationsEnabled = customChordsDurationsEnabled;
+	public void setCustomChordsEnabled(boolean customChordsEnabled) {
+		this.customChordsEnabled = customChordsEnabled;
 	}
 
 	@XmlTransient
@@ -1055,6 +1056,14 @@ public class Section {
 			return UsedPattern.NONE;
 		}
 		return pat.getName();
+	}
+
+	public boolean isCustomDurationsEnabled() {
+		return customDurationsEnabled;
+	}
+
+	public void setCustomDurationsEnabled(boolean customDurationsEnabled) {
+		this.customDurationsEnabled = customDurationsEnabled;
 	}
 
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/Section.java
@@ -359,6 +359,7 @@ public class Section {
 		sec.setCustomChords(getCustomChords());
 		sec.setCustomDurations(getCustomDurations());
 		sec.setCustomChordsEnabled(customChordsEnabled);
+		sec.setCustomDurationsEnabled(customDurationsEnabled);
 		sec.setSectionDuration(sectionDuration);
 		sec.setDisplayAlternateChords(isDisplayAlternateChords());
 		if (sectionBeatDurations != null) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/SwingUtils.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/SwingUtils.java
@@ -7,6 +7,9 @@ import java.awt.Container;
 import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.GridLayout;
+import java.awt.MouseInfo;
+import java.awt.Point;
+import java.awt.PointerInfo;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -21,6 +24,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import javax.swing.JComponent;
+import javax.swing.JFrame;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
@@ -195,5 +199,33 @@ public class SwingUtils {
 			}
 		}
 		return (maybeParent instanceof InstPanel) ? (InstPanel) maybeParent : null;
+	}
+
+	public static Point getMouseLocation() {
+		PointerInfo pi = MouseInfo.getPointerInfo();
+		Point mp = pi.getLocation();
+		//Point mousePointFixed = new Point(mp);
+		/*if (VibeComposerGUI.vibeComposerGUI.getLocation().x < 0) {
+			//mp.x *= -1;
+		}
+		LG.i("Mouse: " + mp.toString());*/
+		return mp;
+	}
+
+	public static void setFrameLocation(JFrame frame, Point loc) {
+		loc.x = Math.max(VibeComposerGUI.vibeComposerGUI.getLocation().x + 50, loc.x);
+		loc.y = Math.max(VibeComposerGUI.vibeComposerGUI.getLocation().y + 50, loc.y);
+		if (loc.x < 0) {
+			Timer tmr = new Timer(50, new ActionListener() {
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					frame.setLocation(loc);
+				}
+			});
+			tmr.setRepeats(false);
+			tmr.start();
+		} else {
+			frame.setLocation(loc);
+		}
 	}
 }

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -6248,7 +6248,6 @@ public class VibeComposerGUI extends JFrame
 			slider.setPaintLabels(true);
 
 			if (loopBeat.isSelected()) {
-				resetPauseInfo();
 				long startPos = (startFromBar.isSelected()) ? delayed : pausedSliderPosition;
 				if (startPos < slider.getValue()) {
 					startPos = slider.getValue();
@@ -6256,6 +6255,7 @@ public class VibeComposerGUI extends JFrame
 				} else {
 					midiNavigate(startPos);
 				}
+				resetPauseInfo();
 
 			} else {
 				String pauseBehavior = pauseBehaviorCombobox.getVal();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -5829,7 +5829,7 @@ public class VibeComposerGUI extends JFrame
 			// solve user chords
 			boolean customChords = userChordsEnabled.isSelected()
 					&& userChords.getChordletsRaw().size() > 0;
-			if ((customChords) || userDurationsEnabled.isEnabled()) {
+			if ((customChords) || userDurationsEnabled.isSelected()) {
 				List<String> chords = userChords.getChordList();
 				List<Double> durations = new ArrayList<>();
 				String[] durationSplit = userChordsDurations.getText().split(",");
@@ -9114,7 +9114,7 @@ public class VibeComposerGUI extends JFrame
 
 		ArpPanel first = (affectedArps.isEmpty() || !affectedArps.get(0).getLockInst()
 				|| (randomizedPanel != null && start == 0)) ? null : affectedArps.get(0);
-		List<RhythmPattern> viablePatterns = RhythmPattern.VIABLE_PATTERNS;
+		List<RhythmPattern> viablePatterns = new ArrayList<>(RhythmPattern.VIABLE_PATTERNS);
 
 		for (int i = start; i < panelCount; i++) {
 			if (randomArpAllSameInst.isSelected() && first != null && fixedInstrument < 0) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -998,9 +998,11 @@ public class VibeComposerGUI extends JFrame
 		LG.i("VibeComposer started in: " + (System.currentTimeMillis() - sysTime)
 				+ " ms! Creating Panels in background...");
 
-		generatePanels(2);
-		generatePanels(3);
-		generatePanels(4);
+		generateInitialMelodyPanels();
+		for (int i = 1; i < 5; i++) {
+			generatePanels(i);
+		}
+
 		composingInProgress = false;
 		LG.i("Panels generated at : " + (System.currentTimeMillis() - sysTime) + " ms!");
 	}
@@ -1631,6 +1633,18 @@ public class VibeComposerGUI extends JFrame
 		}
 	}
 
+	private void generatePanels(int part) {
+		int panelCount = isCustomSection() ? getInstList(part).size()
+				: Integer.valueOf(randomPanelsToGenerate[part].getText());
+		createPanels(part, panelCount, false);
+		recalculateTabPaneCounts();
+		recalculateSoloMuters();
+
+		if (canRegenerateOnChange()) {
+			regenerate();
+		}
+	}
+
 	private void initMelodyGenSettings(int startY, int anchorSide) {
 
 		JPanel scrollableMelodyPanels = new JPanel();
@@ -1691,35 +1705,6 @@ public class VibeComposerGUI extends JFrame
 
 		toggleableComponents.add(melodySettingsExtraPanelShape);
 		toggleableComponents.add(melodySettingsExtraPanelBlocksPatternsCompose);
-	}
-
-	private JPanel initMelodySettingsPlusPlus() {
-		JPanel melodySettingsExtraPanelBlocksPatternsCompose = new JPanel();
-		melodySettingsExtraPanelBlocksPatternsCompose.setAlignmentX(Component.LEFT_ALIGNMENT);
-		melodySettingsExtraPanelBlocksPatternsCompose.setMaximumSize(new Dimension(1800, 50));
-		JLabel melodyExtraLabel3 = new JLabel("MELODY SETTINGS++");
-		melodyExtraLabel3.setPreferredSize(new Dimension(120, 30));
-		melodyExtraLabel3.setBorder(BorderFactory.createBevelBorder(BevelBorder.LOWERED));
-		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyExtraLabel3);
-
-
-		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyUseDirectionsFromProgression);
-		melodySettingsExtraPanelBlocksPatternsCompose
-				.add(new JLabel("<html>Note Target<br>Mode</html>"));
-		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyBlockTargetMode);
-		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyTargetNotesRandomizeOnCompose);
-		melodySettingsExtraPanelBlocksPatternsCompose.add(new JLabel("Pattern Effect"));
-		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyPatternEffect);
-		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyPatternRandomizeOnCompose);
-		JPanel postProcessPanel = new JPanel();
-		postProcessPanel.setBorder(BorderFactory.createBevelBorder(BevelBorder.LOWERED));
-		postProcessPanel.add(new JLabel("<html>Drum Rhythm Accents<br>(Post-process)</html>"));
-		postProcessPanel.add(melodyRhythmAccents);
-		postProcessPanel.add(new JLabel("Mode"));
-		postProcessPanel.add(melodyRhythmAccentsMode);
-		postProcessPanel.add(melodyRhythmAccentsPocket);
-		melodySettingsExtraPanelBlocksPatternsCompose.add(postProcessPanel);
-		return melodySettingsExtraPanelBlocksPatternsCompose;
 	}
 
 	private JPanel initMelodySettings() {
@@ -1802,18 +1787,6 @@ public class VibeComposerGUI extends JFrame
 		return melodySettingsExtraPanelOrg;
 	}
 
-	private void generatePanels(int part) {
-		int panelCount = isCustomSection() ? getInstList(part).size()
-				: Integer.valueOf(randomPanelsToGenerate[part].getText());
-		createPanels(part, panelCount, false);
-		recalculateTabPaneCounts();
-		recalculateSoloMuters();
-
-		if (canRegenerateOnChange()) {
-			regenerate();
-		}
-	}
-
 	private JPanel initMelodySettingsPlus() {
 		JPanel melodySettingsExtraPanelShape = new JPanel();
 		melodySettingsExtraPanelShape.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -1878,6 +1851,35 @@ public class VibeComposerGUI extends JFrame
 		return melodySettingsExtraPanelShape;
 	}
 
+	private JPanel initMelodySettingsPlusPlus() {
+		JPanel melodySettingsExtraPanelBlocksPatternsCompose = new JPanel();
+		melodySettingsExtraPanelBlocksPatternsCompose.setAlignmentX(Component.LEFT_ALIGNMENT);
+		melodySettingsExtraPanelBlocksPatternsCompose.setMaximumSize(new Dimension(1800, 50));
+		JLabel melodyExtraLabel3 = new JLabel("MELODY SETTINGS++");
+		melodyExtraLabel3.setPreferredSize(new Dimension(120, 30));
+		melodyExtraLabel3.setBorder(BorderFactory.createBevelBorder(BevelBorder.LOWERED));
+		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyExtraLabel3);
+
+
+		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyUseDirectionsFromProgression);
+		melodySettingsExtraPanelBlocksPatternsCompose
+				.add(new JLabel("<html>Note Target<br>Mode</html>"));
+		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyBlockTargetMode);
+		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyTargetNotesRandomizeOnCompose);
+		melodySettingsExtraPanelBlocksPatternsCompose.add(new JLabel("Pattern Effect"));
+		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyPatternEffect);
+		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyPatternRandomizeOnCompose);
+		JPanel postProcessPanel = new JPanel();
+		postProcessPanel.setBorder(BorderFactory.createBevelBorder(BevelBorder.LOWERED));
+		postProcessPanel.add(new JLabel("<html>Drum Rhythm Accents<br>(Post-process)</html>"));
+		postProcessPanel.add(melodyRhythmAccents);
+		postProcessPanel.add(new JLabel("Mode"));
+		postProcessPanel.add(melodyRhythmAccentsMode);
+		postProcessPanel.add(melodyRhythmAccentsPocket);
+		melodySettingsExtraPanelBlocksPatternsCompose.add(postProcessPanel);
+		return melodySettingsExtraPanelBlocksPatternsCompose;
+	}
+
 	public static JCheckBox makeCheckBox(String string, boolean b, boolean thick) {
 		JCheckBox cb = new CustomCheckBox(string, b);
 		if (thick) {
@@ -1888,7 +1890,7 @@ public class VibeComposerGUI extends JFrame
 		return cb;
 	}
 
-	public void fixCombinedMelodyTracks() {
+	/*public void fixCombinedMelodyTracks() {
 		if (combineMelodyTracks == null) {
 			return;
 		}
@@ -1912,10 +1914,15 @@ public class VibeComposerGUI extends JFrame
 		if (!foundValid) {
 			melodyPanels.get(0).toggleCombinedMelodyDisabledUI(true);
 		}
-	}
+	}*/
 
 	private void initMelody(int startY, int anchorSide) {
+		constraints.gridy = startY;
+		constraints.anchor = anchorSide;
+		instrumentTabPane.addTab("Melody", melodyParentPanel);
+	}
 
+	private void generateInitialMelodyPanels() {
 		for (int i = 0; i < 3; i++) {
 			MelodyPanel melodyPanel = new MelodyPanel(this);
 			((JPanel) melodyScrollPane.getViewport().getView()).add(melodyPanel);
@@ -1931,8 +1938,6 @@ public class VibeComposerGUI extends JFrame
 				if (i > 1) {
 					melodyPanel.setMuteInst(true);
 				}
-				melodyPanel.toggleCombinedMelodyDisabledUI(
-						combineMelodyTracks != null && !combineMelodyTracks.isSelected());
 				melodyPanel.setVelocityMax(70);
 				melodyPanel.setVelocityMin(40);
 				melodyPanel.setMidiChannel(i + 6);
@@ -1956,18 +1961,10 @@ public class VibeComposerGUI extends JFrame
 				melodyPanel.setNoteLengthMultiplier(108);
 			}
 		}
-
-
-		constraints.gridy = startY;
-		constraints.anchor = anchorSide;
-		instrumentTabPane.addTab("Melody", melodyParentPanel);
-
-
 	}
 
 
 	private void initBass(int startY, int anchorSide) {
-		BassPanel bassPanel = new BassPanel(this);
 
 		JPanel scrollableBassPanels = new JPanel();
 		scrollableBassPanels.setLayout(new BoxLayout(scrollableBassPanels, BoxLayout.Y_AXIS));
@@ -2033,12 +2030,7 @@ public class VibeComposerGUI extends JFrame
 		bassParentPanel.add(borderPanel);
 		bassParentPanel.add(bassScrollPane);
 
-		scrollableBassPanels.add(bassPanel);
-
 		bassSettingsAdvancedPanel.setVisible(false);
-
-
-		bassPanels.add(bassPanel);
 
 		constraints.gridy = startY;
 		constraints.anchor = anchorSide;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -5751,7 +5751,12 @@ public class VibeComposerGUI extends JFrame
 			} else if (regenerate) {
 				midiConfig.setCustomChords(StringUtils.join(MidiGenerator.chordInts, ","));
 				midiConfig.setRegenerateCount(regenerateCount);
-				configHistory.removeItemAt(configHistory.getItemCount() - 1);
+				String oldBookmarkText = configHistory.getItemCount() > 0
+						? configHistory.getLastVal().getBookmarkText()
+						: "";
+				if (StringUtils.isEmpty(oldBookmarkText)) {
+					configHistory.removeItemAt(configHistory.getItemCount() - 1);
+				}
 				configHistory.addItem(midiConfig);
 				configHistory.setSelectedIndex(configHistory.getItemCount() - 1);
 			}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -560,6 +560,7 @@ public class VibeComposerGUI extends JFrame
 	KnobPanel randomArpMaxVel;
 	KnobPanel randomArpMinLength;
 	KnobPanel randomArpMaxLength;
+	JCheckBox randomArpCorrectMelodyNotes;
 	JCheckBox arpCopyMelodyInst;
 
 	// drum gen settings
@@ -2250,6 +2251,8 @@ public class VibeComposerGUI extends JFrame
 		randomArpMaxVel = new DetachedKnobPanel("Max<br>Vel", 90, 1, 127);
 		randomArpMinLength = new DetachedKnobPanel("Min<br>Length", 75, 25, 200);
 		randomArpMaxLength = new DetachedKnobPanel("Max<br>Length", 100, 25, 200);
+		randomArpCorrectMelodyNotes = new CustomCheckBox("<html>Correct Notes<br>by Melody</html>",
+				false);
 
 		arpsSettingsPanel.add(new JLabel("Arp#"));
 		arpsSettingsPanel.add(randomArpHitsPicker);
@@ -2298,6 +2301,7 @@ public class VibeComposerGUI extends JFrame
 		arpSettingsExtraPanel.add(randomArpShiftChance);
 		arpSettingsExtraPanel.add(randomArpMinLength);
 		arpSettingsExtraPanel.add(randomArpMaxLength);
+		arpSettingsExtraPanel.add(randomArpCorrectMelodyNotes);
 		arpSettingsExtraPanel.add(clearArpPatternSeeds);
 		toggleableComponents.add(arpSettingsExtraPanel);
 
@@ -7832,7 +7836,7 @@ public class VibeComposerGUI extends JFrame
 		cs.add(arpCopyMelodyInst);
 		cs.add(randomArpAllSameInst);
 		cs.add(randomArpLimitPowerOfTwo);
-		cs.add(randomArpUseOctaveAdjustments);
+		cs.add(null); // randomArpUseOctaveAdjustments
 		cs.add(randomArpMaxRepeat);
 		cs.add(randomArpMinVel);
 		cs.add(randomArpMaxVel);
@@ -7896,14 +7900,6 @@ public class VibeComposerGUI extends JFrame
 
 		// ---------------- VIBECOMPOSER 2 ------------------------------------
 
-		// melody panel
-
-		// bass panel
-
-		// chords panel
-
-		// arps panel
-
 		// drum panel
 		cs.add(randomDrumHitsMultiplierOnGenerate);
 		cs.add(drumPartPresetAddCheckbox);
@@ -7914,11 +7910,16 @@ public class VibeComposerGUI extends JFrame
 		cs.add(copyChordsAfterGenerate);
 		cs.add(miniScorePopup);
 
+		// arps panel
+		cs.add(randomArpCorrectMelodyNotes);
+
 		return cs;
 	}
 
 	public static void setComponent(Component c, Integer num, boolean repaint) {
-		if (c instanceof ScrollComboPanel) {
+		if (c == null) {
+			return;
+		} else if (c instanceof ScrollComboPanel) {
 			ScrollComboPanel csc = ((ScrollComboPanel) c);
 			if (csc.getItemCount() > 0) {
 				csc.setSelectedIndex(Math.min(num, csc.getItemCount()));
@@ -8084,6 +8085,7 @@ public class VibeComposerGUI extends JFrame
 
 		// arps
 		gc.setUseOctaveAdjustments(randomArpUseOctaveAdjustments.isSelected());
+		gc.setRandomArpCorrectMelodyNotes(randomArpCorrectMelodyNotes.isSelected());
 
 		// drums
 		boolean isCustomMidiDevice = midiMode.isSelected()
@@ -8220,6 +8222,7 @@ public class VibeComposerGUI extends JFrame
 
 		// arps
 		randomArpUseOctaveAdjustments.setSelected(gc.isUseOctaveAdjustments());
+		randomArpCorrectMelodyNotes.setSelected(gc.isRandomArpCorrectMelodyNotes());
 
 		arrSection.setVisible(true);
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -8475,63 +8475,62 @@ public class VibeComposerGUI extends JFrame
 		Collections.sort(removedPanels, Comparator.comparing(e1 -> e1.getPanelOrder()));
 		int[] melodyChannels = { 1, 7, 8 };
 		panelCount -= remainingPanels.size();
+		ChordSpanFill[] melodyFills = { ChordSpanFill.ALL, ChordSpanFill.ALL, ChordSpanFill.EVEN,
+				ChordSpanFill.ODD, ChordSpanFill.HALF1, ChordSpanFill.HALF2 };
 		for (int panelIndex = 0; panelIndex < panelCount; panelIndex++) {
 			boolean needNewChannel = false;
-			MelodyPanel melodyPanel = null;
+			MelodyPanel ip = null;
 			if (randomizedPanel != null) {
-				melodyPanel = randomizedPanel;
+				ip = randomizedPanel;
 			} else {
 				if (panelIndex < removedPanels.size()) {
-					melodyPanel = removedPanels.get(panelIndex);
+					ip = removedPanels.get(panelIndex);
 				} else {
-					melodyPanel = (MelodyPanel) addInstPanelToLayout(0);
+					ip = (MelodyPanel) addInstPanelToLayout(0);
 					needNewChannel = true;
 				}
 			}
 			if (randomizeInstOnComposeOrGen.isSelected()) {
-				melodyPanel.setInstrument(melodyPanel.getInstrumentBox().getRandomInstrument());
+				ip.setInstrument(ip.getInstrumentBox().getRandomInstrument());
 			}
 
-			melodyPanel.setSpeed(panelGenerator.nextInt(25));
-			melodyPanel.setMaxBlockChange(3 + panelGenerator.nextInt(5));
+			ip.setSpeed(panelGenerator.nextInt(25));
+			ip.setMaxBlockChange(3 + panelGenerator.nextInt(5));
 			//melodyPanel.setSplitChance(melodyRand.nextInt(15));
-			melodyPanel.setNoteExceptionChance(10 + panelGenerator.nextInt(15));
-			melodyPanel.setMaxNoteExceptions(panelGenerator.nextInt(2));
-			melodyPanel.setLeadChordsChance(panelGenerator.nextInt(50));
+			ip.setNoteExceptionChance(10 + panelGenerator.nextInt(15));
+			ip.setMaxNoteExceptions(panelGenerator.nextInt(2));
+			ip.setLeadChordsChance(panelGenerator.nextInt(50));
 
-			ChordSpanFill[] melodyFills = { ChordSpanFill.ALL, ChordSpanFill.ALL,
-					ChordSpanFill.EVEN, ChordSpanFill.ODD, ChordSpanFill.HALF1,
-					ChordSpanFill.HALF2 };
-			melodyPanel.setChordSpanFill(melodyFills[panelGenerator.nextInt(melodyFills.length)]);
-			melodyPanel.setFillFlip(false);
+			ip.setChordSpanFill(melodyFills[panelGenerator.nextInt(melodyFills.length)]);
+			ip.setFillFlip(false);
 
-			int panelOrder = melodyPanel.getPanelOrder();
+			int panelOrder = ip.getPanelOrder();
 			if (panelOrder > 1) {
-				melodyPanel.setFillPauses(true);
-				melodyPanel.setPauseChance(50 + panelGenerator.nextInt(40));
+				ip.setFillPauses(true);
+				ip.setPauseChance(50 + panelGenerator.nextInt(40));
 				/*melodyPanel.toggleCombinedMelodyDisabledUI(
 						combineMelodyTracks != null && !combineMelodyTracks.isSelected());*/
-				melodyPanel.setVelocityMax(65 + panelGenerator.nextInt(20));
-				melodyPanel.setVelocityMin(40 + panelGenerator.nextInt(20));
+				ip.setVelocityMax(65 + panelGenerator.nextInt(20));
+				ip.setVelocityMin(40 + panelGenerator.nextInt(20));
 				if (panelOrder % 2 == 0) {
-					melodyPanel.setTranspose(0);
-					melodyPanel.getPanSlider().setValue(75);
+					ip.setTranspose(0);
+					ip.getPanSlider().setValue(75);
 				} else {
-					melodyPanel.setTranspose(-12);
-					melodyPanel.getPanSlider().setValue(25);
+					ip.setTranspose(-12);
+					ip.getPanSlider().setValue(25);
 				}
-				melodyPanel.setNoteLengthMultiplier(70 + panelGenerator.nextInt(40));
+				ip.setNoteLengthMultiplier(70 + panelGenerator.nextInt(40));
 			} else {
-				melodyPanel.setFillPauses(panelGenerator.nextBoolean());
-				melodyPanel.setPauseChance(panelGenerator.nextInt(35));
-				melodyPanel.setTranspose(12);
-				melodyPanel.setVelocityMax(80 + panelGenerator.nextInt(30));
-				melodyPanel.setVelocityMin(50 + panelGenerator.nextInt(25));
-				melodyPanel.setNoteLengthMultiplier(100 + panelGenerator.nextInt(25));
+				ip.setFillPauses(panelGenerator.nextBoolean());
+				ip.setPauseChance(panelGenerator.nextInt(35));
+				ip.setTranspose(12);
+				ip.setVelocityMax(80 + panelGenerator.nextInt(30));
+				ip.setVelocityMin(50 + panelGenerator.nextInt(25));
+				ip.setNoteLengthMultiplier(100 + panelGenerator.nextInt(25));
 			}
 
 			if (needNewChannel) {
-				melodyPanel.setMidiChannel(melodyChannels[(panelOrder - 1) % 3]);
+				ip.setMidiChannel(melodyChannels[(panelOrder - 1) % 3]);
 			}
 		}
 		repaint();
@@ -8566,6 +8565,10 @@ public class VibeComposerGUI extends JFrame
 		}
 		Collections.sort(removedPanels, Comparator.comparing(e1 -> e1.getPanelOrder()));
 		panelCount -= remainingPanels.size();
+		ChordSpanFill[] bassFills = { ChordSpanFill.ALL, ChordSpanFill.ALL, ChordSpanFill.EVEN,
+				ChordSpanFill.ODD, ChordSpanFill.HALF1, ChordSpanFill.HALF2 };
+		List<RhythmPattern> viablePatterns = RhythmPattern.VIABLE_PATTERNS;
+
 		for (int panelIndex = 0; panelIndex < panelCount; panelIndex++) {
 			boolean needNewChannel = false;
 			BassPanel ip = null;
@@ -8582,7 +8585,56 @@ public class VibeComposerGUI extends JFrame
 			if (randomizeInstOnComposeOrGen.isSelected()) {
 				ip.setInstrument(ip.getInstrumentBox().getRandomInstrument());
 			}
+			ip.setChordSpanFill(bassFills[panelGenerator.nextInt(bassFills.length)]);
+			ip.setFillFlip(false);
 			ip.setPatternSeed(seed);
+
+			int panelOrder = ip.getPanelOrder();
+			if (panelOrder > 1) {
+				ip.setPauseChance(30 + panelGenerator.nextInt(40));
+				/*melodyPanel.toggleCombinedMelodyDisabledUI(
+						combineMelodyTracks != null && !combineMelodyTracks.isSelected());*/
+				ip.setVelocityMax(50 + panelGenerator.nextInt(20));
+				ip.setVelocityMin(30 + panelGenerator.nextInt(20));
+				if (panelOrder % 2 == 0) {
+					ip.setTranspose(0);
+				} else {
+					ip.setTranspose(12);
+				}
+				ip.setNoteLengthMultiplier(60 + panelGenerator.nextInt(40));
+
+				// default SINGLE = 4
+				RhythmPattern pattern = RhythmPattern.SINGLE;
+				// use pattern in 20% of the cases if checkbox selected
+				int patternChance = 50;
+				if (panelGenerator.nextInt(100) < patternChance) {
+					// TODO: BASS SETTINGS toggles
+					if (true) {
+						pattern = viablePatterns.get(panelGenerator.nextInt(viablePatterns.size()));
+						if (pattern == RhythmPattern.MELODY1) {
+							pattern = RhythmPattern.FULL;
+						}
+					}
+				}
+				ip.setPattern(pattern);
+
+				int hits = 4;
+				while (panelGenerator.nextBoolean() && hits < 16) {
+					hits *= 2;
+				}
+				if ((hits / ip.getChordSpan() >= 8)) {
+					hits /= 2;
+				}
+
+				ip.setHitsPerPattern(hits * 2);
+
+			} else {
+				ip.setPauseChance(panelGenerator.nextInt(10));
+				ip.setTranspose(0);
+				ip.setVelocityMax(60 + panelGenerator.nextInt(30));
+				ip.setVelocityMin(40 + panelGenerator.nextInt(25));
+				ip.setNoteLengthMultiplier(80 + panelGenerator.nextInt(25));
+			}
 
 			if (needNewChannel) {
 				ip.setMidiChannel(9);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -2950,11 +2950,14 @@ public class VibeComposerGUI extends JFrame
 				Section sec = actualArrangement.getSections()
 						.get(arrSection.getSelectedIndex() - 1);
 				if (sec.hasCustomizedParts()) {
-					sec.resetCustomizedParts();
+					sec.resetCustomizedParts(VibeComposerGUI.instrumentTabPane.getSelectedIndex());
 					setActualModel(actualArrangement.convertToActualTableModel(), false);
-					CheckButton cb = arrSection.getCurrentButton();
-					cb.setText(cb.getText().substring(0, cb.getText().length() - 1));
-					cb.repaint();
+					if (!sec.hasCustomizedParts()) {
+						CheckButton cb = arrSection.getCurrentButton();
+						cb.setText(cb.getText().substring(0, cb.getText().length() - 1));
+						cb.repaint();
+					}
+
 					arrSection.setSelectedIndexWithProperty(arrSection.getSelectedIndex(), true);
 				}
 			}
@@ -9693,8 +9696,8 @@ public class VibeComposerGUI extends JFrame
 
 
 	public static boolean canRegenerateOnChange() {
-		return sequencer != null && regenerateWhenValuesChange.isSelected() && !heavyBackgroundTasksInProgress
-				&& arrSection.getSelectedIndex() == 0;
+		return sequencer != null && regenerateWhenValuesChange.isSelected()
+				&& !heavyBackgroundTasksInProgress && arrSection.getSelectedIndex() == 0;
 	}
 
 	public static int calculateSectionMeasureStart(int sectIndex) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -1216,7 +1216,7 @@ public class VibeComposerGUI extends JFrame
 
 					recalculateTabPaneCounts();
 					recalculateGenerationCounts();
-					manualArrangement.setSelected(false);
+					//manualArrangement.setSelected(false);
 					vibeComposerGUI.repaint();
 				} catch (JAXBException | IOException e) {
 					e.printStackTrace();
@@ -1242,6 +1242,7 @@ public class VibeComposerGUI extends JFrame
 		String filePath = PRESET_FOLDER + "/" + presetName + ".xml";
 		saveGuiPresetFileByFilePath(filePath);
 		presetLoadBox.addItem(presetName);
+		new TemporaryInfoPopup("Saved preset: " + presetName, 2000);
 	}
 
 	private void initExtraSettings() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -4342,6 +4342,28 @@ public class VibeComposerGUI extends JFrame
 		});
 		customChordsPanel.add(dotdotChordsButton);
 
+		JButton ivChordsButton = new JButton("Ch");
+		ivChordsButton.setPreferredSize(new Dimension(25, 25));
+		ivChordsButton.setMargin(new Insets(0, 0, 0, 0));
+		ivChordsButton.addActionListener(new ActionListener() {
+
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				Pair<List<String>, List<Double>> normalizedChords = solveUserChords(
+						userChords.getChordListString(), userChordsDurations.getText());
+				if (normalizedChords != null) {
+					List<String> chords = normalizedChords.getLeft();
+					List<String> chordStrings = new ArrayList<>();
+					chords.forEach(ch -> {
+						chordStrings
+								.add(MidiUtils.chordStringFromPitches(MidiUtils.mappedChord(ch)));
+					});
+					userChords.setupChords(chordStrings);
+				}
+			}
+		});
+		customChordsPanel.add(ivChordsButton);
+
 		JButton resetChordsButton = new JButton("R");
 		resetChordsButton.setPreferredSize(new Dimension(25, 25));
 		resetChordsButton.setMargin(new Insets(0, 0, 0, 0));

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -616,6 +616,7 @@ public class VibeComposerGUI extends JFrame
 	public static KnobPanel longProgressionSimilarity;
 	ScrollComboBox<String> keyChangeTypeSelection;
 	public static CheckButton userChordsEnabled;
+	public static CheckButton userDurationsEnabled;
 	public static JTextField userChordsDurations;
 	public static ChordletPanel userChords;
 
@@ -1611,7 +1612,7 @@ public class VibeComposerGUI extends JFrame
 			secConfig.setSectionSwingOverride(sectionGuiConfig.getGlobalSwingOverride());*/
 			currentSec.setCustomChords(sectionGuiConfig.getCustomChords());
 			currentSec.setCustomDurations(sectionGuiConfig.getCustomChordDurations());
-			currentSec.setCustomChordsDurationsEnabled(true);
+			currentSec.setCustomChordsEnabled(true);
 			arrSection.getCurrentButton().repaint();
 			switchPanelsForSectionSelection(arrSection.getVal());
 
@@ -3794,7 +3795,7 @@ public class VibeComposerGUI extends JFrame
 										/ 2; j++) {
 									// in case of swap chords, behave same as custom chords
 									if (sectionVars.get(j) > 0
-											|| (j == 1 && sec.isCustomChordsDurationsEnabled())) {
+											|| (j == 1 && sec.isCustomChordsEnabled())) {
 										g.drawImage(SECTION_VARIATIONS_ICONS.get(j), currentX, 6,
 												this);
 									}
@@ -3865,7 +3866,7 @@ public class VibeComposerGUI extends JFrame
 				? (int) sec.getSectionVariations().stream().filter(e -> e > 0).count()
 				: 0;
 		count += (sec.isTransition() ? 1 : 0);
-		count += (sec.isCustomChordsDurationsEnabled() ? 1 : 0);
+		count += (sec.isCustomChordsEnabled() ? 1 : 0);
 		int color = 0;
 		int total = Section.sectionVariationNames.length + 1;
 		if (isDarkMode) {
@@ -4413,9 +4414,9 @@ public class VibeComposerGUI extends JFrame
 		});
 		customChordsPanel.add(chordTransformButton);
 
+		userDurationsEnabled = new CheckButton("Custom Durations", false);
+		customChordsPanel.add(userDurationsEnabled);
 		userChordsDurations = new JTextField("4,4,4,4", 9);
-		JLabel userChordsDurationsLabel = new JLabel("Chord durations:");
-		customChordsPanel.add(userChordsDurationsLabel);
 		customChordsPanel.add(userChordsDurations);
 
 
@@ -4424,11 +4425,11 @@ public class VibeComposerGUI extends JFrame
 		everythingPanel.add(customChordsPanel, constraints);
 
 		toggleableComponents.add(twoExChordsButton);
+		toggleableComponents.add(userDurationsEnabled);
 		toggleableComponents.add(userChordsDurations);
 		toggleableComponents.add(dotdotChordsButton);
 		toggleableComponents.add(ddChordsButton);
 		toggleableComponents.add(normalizeChordsButton);
-		toggleableComponents.add(userChordsDurationsLabel);
 
 	}
 
@@ -5827,15 +5828,28 @@ public class VibeComposerGUI extends JFrame
 
 			// solve user chords
 			String chords = userChords.getChordListString();
-			if (userChordsEnabled.isSelected() && userChords.getChordletsRaw().size() > 0) {
+			boolean customChords = userChordsEnabled.isSelected()
+					&& userChords.getChordletsRaw().size() > 0;
+			if ((customChords) || userDurationsEnabled.isEnabled()) {
 				Pair<List<String>, List<Double>> solvedChordsDurations = solveUserChords(chords,
 						userChordsDurations.getText());
-				if (solvedChordsDurations != null) {
-					MidiGenerator.userChords = solvedChordsDurations.getLeft();
-					MidiGenerator.userChordsDurations = solvedChordsDurations.getRight();
+				if (userDurationsEnabled.isSelected()) {
+					if (solvedChordsDurations != null) {
+						MidiGenerator.userChordsDurations = solvedChordsDurations.getRight();
+					} else {
+						MidiGenerator.userChordsDurations.clear();
+					}
+				} else {
+					MidiGenerator.userChordsDurations.clear();
+				}
+				if (customChords) {
+					if (solvedChordsDurations != null) {
+						MidiGenerator.userChords = solvedChordsDurations.getLeft();
+					} else {
+						MidiGenerator.userChords.clear();
+					}
 				} else {
 					MidiGenerator.userChords.clear();
-					MidiGenerator.userChordsDurations.clear();
 				}
 			} else {
 				MidiGenerator.userChords.clear();

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -9035,6 +9035,10 @@ public class VibeComposerGUI extends JFrame
 				if (panelGenerator.nextInt(100) >= randomChordShiftChance.getInt()) {
 					maxShift /= 2;
 				}
+				if (beatDurationMultiplier != null && beatDurationMultiplier.getVal() < 0.75) {
+					maxShift /= 2;
+				}
+
 				ip.setPatternShift(maxShift > 0 ? (panelGenerator.nextInt(maxShift) + 1) : 0);
 			} else {
 				ip.setPatternShift(0);
@@ -9283,6 +9287,10 @@ public class VibeComposerGUI extends JFrame
 			if (panelGenerator.nextInt(100) < randomArpShiftChance.getInt()) {
 				//LG.d("Arp getPattern: " + ip.getPattern().name());
 				int maxShift = Math.min(ip.getPattern().maxShift, ip.getHitsPerPattern() - 1);
+
+				if (beatDurationMultiplier != null && beatDurationMultiplier.getVal() < 0.75) {
+					maxShift /= 2;
+				}
 				ip.setPatternShift(maxShift > 0 ? (panelGenerator.nextInt(maxShift) + 1) : 0);
 			} else {
 				ip.setPatternShift(0);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -983,8 +983,10 @@ public class VibeComposerGUI extends JFrame
 		pack();
 		LG.i("Dark, pack: " + (System.currentTimeMillis() - sysTime) + " ms!");
 
+		boolean presetLoaded = false;
 		if (presetLoadBox.getVal().equalsIgnoreCase("default")) {
 			loadPreset();
+			presetLoaded = true;
 		}
 
 		initKeyboardListener();
@@ -998,9 +1000,11 @@ public class VibeComposerGUI extends JFrame
 		LG.i("VibeComposer started in: " + (System.currentTimeMillis() - sysTime)
 				+ " ms! Creating Panels in background...");
 
-		generateInitialMelodyPanels();
-		for (int i = 1; i < 5; i++) {
-			generatePanels(i);
+		if (!presetLoaded) {
+			generateInitialMelodyPanels();
+			for (int i = 1; i < 5; i++) {
+				generatePanels(i);
+			}
 		}
 
 		composingInProgress = false;
@@ -1924,10 +1928,8 @@ public class VibeComposerGUI extends JFrame
 
 	private void generateInitialMelodyPanels() {
 		for (int i = 0; i < 3; i++) {
-			MelodyPanel melodyPanel = new MelodyPanel(this);
-			((JPanel) melodyScrollPane.getViewport().getView()).add(melodyPanel);
+			MelodyPanel melodyPanel = (MelodyPanel) addInstPanelToLayout(0);
 			melodyPanel.setInstrument(73);
-			melodyPanels.add(melodyPanel);
 			melodyPanel.setPanelOrder(i + 1);
 			if (i > 0) {
 				melodyPanel.setAccents(50);
@@ -8280,29 +8282,29 @@ public class VibeComposerGUI extends JFrame
 
 	// -------------- GENERIC INST PANEL METHODS ----------------------------
 
-	public InstPanel addInstPanelToLayout(int inst) {
-		return addInstPanelToLayout(inst, null, true);
+	public InstPanel addInstPanelToLayout(int part) {
+		return addInstPanelToLayout(part, null, true);
 	}
 
-	public InstPanel addInstPanelToLayout(int inst, boolean recalc) {
-		return addInstPanelToLayout(inst, null, recalc);
+	public InstPanel addInstPanelToLayout(int part, boolean recalc) {
+		return addInstPanelToLayout(part, null, recalc);
 	}
 
-	public InstPanel addInstPanelToLayout(int inst, InstPart initializingPart,
+	public InstPanel addInstPanelToLayout(int part, InstPart initializingPart,
 			boolean recalcArrangement) {
-		InstPanel ip = InstPanel.makeInstPanel(inst, this);
-		List<InstPanel> affectedPanels = getAffectedPanels(inst);
+		InstPanel ip = InstPanel.makeInstPanel(part, this);
+		List<InstPanel> affectedPanels = getAffectedPanels(part);
 		int panelOrder = (affectedPanels.size() > 0) ? getValidPanelNumber(affectedPanels) : 1;
 
 		ip.getToggleableComponents().forEach(e -> e.setVisible(isFullMode));
 		if (isCustomSection()) {
 			ip.toggleGlobalElements(false);
 			ip.toggleEnabledCopyRemove(false);
-			if (inst == 4) {
+			if (part == 4) {
 				ip.getInstrumentBox().setEnabled(true);
 			}
 		} else {
-			ip.setBackground(OMNI.alphen(instColors[inst], 60));
+			ip.setBackground(OMNI.alphen(instColors[part], 60));
 		}
 
 		if (initializingPart != null) {
@@ -8319,10 +8321,10 @@ public class VibeComposerGUI extends JFrame
 		}
 
 
-		if (inst < 4 || !bottomUpReverseDrumPanels.isSelected()) {
-			((JPanel) getInstPane(inst).getViewport().getView()).add(ip, panelOrder - 1);
+		if (part < 4 || !bottomUpReverseDrumPanels.isSelected()) {
+			((JPanel) getInstPane(part).getViewport().getView()).add(ip, panelOrder - 1);
 		} else {
-			((JPanel) getInstPane(inst).getViewport().getView()).add(ip,
+			((JPanel) getInstPane(part).getViewport().getView()).add(ip,
 					affectedPanels.size() - panelOrder);
 		}
 		return ip;

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -7568,7 +7568,7 @@ public class VibeComposerGUI extends JFrame
 
 	private void recalculateTabPaneCounts() {
 		instrumentTabPane.setTitleAt(0, "Melody (" + melodyPanels.size() + ")");
-		instrumentTabPane.setTitleAt(1, " Bass  (1)");
+		instrumentTabPane.setTitleAt(1, " Bass  (" + bassPanels.size() + ")");
 		instrumentTabPane.setTitleAt(2, "Chords (" + chordPanels.size() + ")");
 		instrumentTabPane.setTitleAt(3, " Arps  (" + arpPanels.size() + ")");
 		instrumentTabPane.setTitleAt(4, " Drums (" + drumPanels.size() + ")");
@@ -9248,17 +9248,20 @@ public class VibeComposerGUI extends JFrame
 
 			RhythmPattern pattern = RhythmPattern.FULL;
 			// use pattern if checkbox selected and %chance 
-			if (panelGenerator.nextInt(100) < 30 + arpPanels.size() * 5) {
+			int patternChanceIncrease = (ip.getPanelOrder() < 4 || arpPanels.size() < 3) ? 0
+					: arpPanels.size() * 5;
+			int fillChanceIncrease = (ip.getPanelOrder() < 4 || arpPanels.size() < 3) ? 0
+					: (arpPanels.size() - 3) * 5;
+			if (panelGenerator.nextInt(100) < (30 + patternChanceIncrease)) {
 				if (randomArpPattern.isSelected()) {
 					pattern = viablePatterns.get(panelGenerator.nextInt(viablePatterns.size()));
 				}
 			}
 			ip.setPattern(pattern);
 			if (randomArpUseChordFill.isSelected()) {
-				int exoticFillChanceIncrease = (arpPanels.size() > 3) ? (arpPanels.size() - 3) * 5
-						: 0;
-				ip.setChordSpanFill(ChordSpanFill
-						.getWeighted(panelGenerator.nextInt(100) + exoticFillChanceIncrease));
+				int fillWeight = OMNI.clampChance(
+						panelGenerator.nextInt(100 - fillChanceIncrease) + fillChanceIncrease);
+				ip.setChordSpanFill(ChordSpanFill.getWeighted(fillWeight));
 			} else {
 				ip.setChordSpanFill(ChordSpanFill.ALL);
 			}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -5827,27 +5827,31 @@ public class VibeComposerGUI extends JFrame
 			MidiGenerator.LAST_CHORD = chordSelect(lastChordSelection.getVal());
 
 			// solve user chords
-			String chords = userChords.getChordListString();
 			boolean customChords = userChordsEnabled.isSelected()
 					&& userChords.getChordletsRaw().size() > 0;
 			if ((customChords) || userDurationsEnabled.isEnabled()) {
-				Pair<List<String>, List<Double>> solvedChordsDurations = solveUserChords(chords,
-						userChordsDurations.getText());
-				if (userDurationsEnabled.isSelected()) {
-					if (solvedChordsDurations != null) {
-						MidiGenerator.userChordsDurations = solvedChordsDurations.getRight();
-					} else {
-						MidiGenerator.userChordsDurations.clear();
-					}
-				} else {
-					MidiGenerator.userChordsDurations.clear();
+				List<String> chords = userChords.getChordList();
+				List<Double> durations = new ArrayList<>();
+				String[] durationSplit = userChordsDurations.getText().split(",");
+				if ((userChordsEnabled.isSelected() && durationSplit.length < chords.size())
+						|| !userDurationsEnabled.isSelected()) {
+					durationSplit = null;
 				}
-				if (customChords) {
-					if (solvedChordsDurations != null) {
-						MidiGenerator.userChords = solvedChordsDurations.getLeft();
-					} else {
-						MidiGenerator.userChords.clear();
+
+				try {
+					for (int i = 0; i < chords.size(); i++) {
+						durations.add(durationSplit != null
+								? (stretchMidi.getInt() * Double.valueOf(durationSplit[i]) / 100.0)
+								: MidiGenerator.Durations.WHOLE_NOTE);
 					}
+				} catch (Exception e) {
+					new TemporaryInfoPopup("Invalid durations!", 3000);
+				}
+
+				MidiGenerator.userChordsDurations = durations;
+
+				if (customChords) {
+					MidiGenerator.userChords = chords;
 				} else {
 					MidiGenerator.userChords.clear();
 				}
@@ -6722,7 +6726,6 @@ public class VibeComposerGUI extends JFrame
 		MidiGenerator.FIRST_CHORD = chordSelect(firstChordSelection.getVal());
 		MidiGenerator.LAST_CHORD = chordSelect(lastChordSelection.getVal());
 		MidiGenerator.userChords.clear();
-		MidiGenerator.userChordsDurations.clear();
 		mg.generatePrettyUserChords(new Random().nextInt(),
 				userChords.chordCount() > 0 ? userChords.chordCount()
 						: MidiGenerator.gc.getFixedDuration(),
@@ -7611,14 +7614,14 @@ public class VibeComposerGUI extends JFrame
 		}
 	}
 
-	public static Pair<List<String>, List<Double>> solveUserChords(JTextField customChords,
+	/*public static Pair<List<String>, List<Double>> solveUserChords(JTextField customChords,
 			JTextField customChordsDurations) {
-
+	
 		String text = customChords.getText().replaceAll(" ", "");
 		customChords.setText(text);
 		String[] userChordsSplit = text.split(",");
 		//LG.i((StringUtils.join(userChordsSplit, ";")));
-
+	
 		String[] userChordsDurationsSplit = customChordsDurations.getText().split(",");
 		if (userChordsSplit.length != userChordsDurationsSplit.length) {
 			List<Integer> durations = IntStream.iterate(4, n -> n).limit(userChordsSplit.length)
@@ -7627,7 +7630,7 @@ public class VibeComposerGUI extends JFrame
 			userChordsDurationsSplit = customChordsDurations.getText().split(",");
 		}
 		return solveUserChords(userChordsSplit, userChordsDurationsSplit);
-	}
+	}*/
 
 	public static Pair<List<String>, List<Double>> solveUserChords(String customChords,
 			String customChordsDurations) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -734,6 +734,7 @@ public class VibeComposerGUI extends JFrame
 	public static JCheckBox highlightPatterns;
 	public static JCheckBox highlightScoreNotes;
 	public static JCheckBox customFilenameAddTimestamp;
+	public static JCheckBox miniScorePopup;
 
 
 	public static void main(String args[]) {
@@ -1446,6 +1447,7 @@ public class VibeComposerGUI extends JFrame
 		highlightPatterns = new CustomCheckBox("Highlight Sequencer Pattern (-Perf)", true);
 		highlightScoreNotes = new CustomCheckBox("Highlight Score Notes (-Perf)", true);
 		customFilenameAddTimestamp = new CustomCheckBox("Add Timestamp To Custom Filenames", false);
+		miniScorePopup = new CustomCheckBox("Mini Score Popup", true);
 		displayVeloRectValues.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -1477,6 +1479,7 @@ public class VibeComposerGUI extends JFrame
 		displayStylePanel.add(highlightPatterns);
 		displayStylePanel.add(highlightScoreNotes);
 		displayStylePanel.add(customFilenameAddTimestamp);
+		displayStylePanel.add(miniScorePopup);
 		extraSettingsPanel.add(displayStylePanel);
 
 
@@ -5051,13 +5054,27 @@ public class VibeComposerGUI extends JFrame
 
 
 		showScore = new JButton("Show Score Tab");
-		showScore.addActionListener(new ActionListener() {
+		showScore.addMouseListener(new MouseAdapter() {
 
 			@Override
-			public void actionPerformed(ActionEvent e) {
+			public void mouseClicked(MouseEvent e) {
 				if (scorePanel != null) {
 					if (instrumentTabPane.getComponentCount() == 8) {
 						instrumentTabPane.remove(scoreScrollPane);
+						if (VibeComposerGUI.miniScorePopup.isSelected()) {
+							ShowPanelBig.beatWidthBase = 600;
+							ShowPanelBig.beatWidthBaseIndex = 0;
+							scorePanel.updatePanelHeight(300);
+							//scoreScrollPane.setMaximumSize(new Dimension(600, 300));
+							scorePanel.getShowArea().setNoteHeight(4);
+							scorePanel.setScore();
+							scorePanel.setAlignmentX(LEFT_ALIGNMENT);
+							scoreScrollPane.repaint();
+							/*SwingUtilities.invokeLater(() -> {
+								ShowPanelBig.zoomIn(ShowPanelBig.areaScrollPane, e.getPoint(), 0.0,
+										0.0);
+							});*/
+						}
 						scorePopup = new ShowScorePopup(scoreScrollPane);
 					} else {
 						if (scorePopup != null) {
@@ -7980,6 +7997,7 @@ public class VibeComposerGUI extends JFrame
 		// extra settings
 		cs.add(globalNoteLengthMultiplier);
 		cs.add(copyChordsAfterGenerate);
+		cs.add(miniScorePopup);
 
 		return cs;
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -7944,6 +7944,10 @@ public class VibeComposerGUI extends JFrame
 	}
 
 	public static Integer getComponentValue(Component c) {
+		if (c == null) {
+			return 0;
+		}
+
 		if (c instanceof ScrollComboPanel) {
 			return ((ScrollComboPanel) c).getSelectedIndex();
 		} else if (c instanceof KnobPanel) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -1625,6 +1625,9 @@ public class VibeComposerGUI extends JFrame
 			currentSec.setCustomChords(sectionGuiConfig.getCustomChords());
 			currentSec.setCustomDurations(sectionGuiConfig.getCustomChordDurations());
 			currentSec.setCustomChordsEnabled(true);
+			if (!"4,4,4,4".equals(currentSec.getCustomDurations())) {
+				currentSec.setCustomDurationsEnabled(true);
+			}
 			arrSection.getCurrentButton().repaint();
 			switchPanelsForSectionSelection(arrSection.getVal());
 
@@ -8088,6 +8091,7 @@ public class VibeComposerGUI extends JFrame
 		gc.setCustomChordsEnabled(userChordsEnabled.isSelected());
 		gc.setCustomChords(StringUtils.join(MidiGenerator.chordInts, ","));
 		gc.setCustomChordDurations(userChordsDurations.getText());
+		gc.setCustomDurationsEnabled(userDurationsEnabled.isSelected());
 		gc.setSpiceChance(spiceChance.getInt());
 		gc.setSpiceParallelChance(spiceParallelChance.getInt());
 		gc.setDimAugDom7thEnabled(spiceAllowDimAug.isSelected());
@@ -8231,6 +8235,7 @@ public class VibeComposerGUI extends JFrame
 		userChordsEnabled.setSelected(gc.isCustomChordsEnabled());
 		userChords.setupChords(gc.getCustomChords());
 		userChordsDurations.setText(gc.getCustomChordDurations());
+		userDurationsEnabled.setSelected(gc.isCustomDurationsEnabled());
 
 		// arps
 		randomArpUseOctaveAdjustments.setSelected(gc.isUseOctaveAdjustments());

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -2910,7 +2910,7 @@ public class VibeComposerGUI extends JFrame
 			actualArrangement.getSections().forEach(s -> s.resetCustomizedParts());
 			setActualModel(actualArrangement.convertToActualTableModel(), false);
 			arrSection.getButtons().forEach(cb -> {
-				if (!GLOBAL.equals(cb.getText())) {
+				if (!GLOBAL.equals(cb.getText()) && cb.getText().contains("*")) {
 					cb.setText(cb.getText().substring(0, cb.getText().length() - 1));
 					repaint();
 				}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -502,7 +502,6 @@ public class VibeComposerGUI extends JFrame
 	public static ScrollComboBox<String> melodyBlockTargetMode;
 	JCheckBox melodyTargetNotesRandomizeOnCompose;
 	ScrollComboBox<String> melodyPatternEffect;
-	JCheckBox melodyPatternFlexible;
 	ScrollComboBox<String> melodyRhythmAccents;
 	ScrollComboBox<String> melodyRhythmAccentsMode;
 	JCheckBox melodyRhythmAccentsPocket;
@@ -1689,7 +1688,6 @@ public class VibeComposerGUI extends JFrame
 		ScrollComboBox.addAll(new String[] { "Rhythm", "Notes", "Rhythm+Notes" },
 				melodyPatternEffect);
 		melodyPatternEffect.setSelectedIndex(2);
-		melodyPatternFlexible = makeCheckBox("Flexible", true, false);
 		melodyPatternRandomizeOnCompose = makeCheckBox(
 				"<html>Randomize Pattern<br> on Compose</html>", true, true);
 		melodyRhythmAccents = new ScrollComboBox<>();
@@ -1735,7 +1733,6 @@ public class VibeComposerGUI extends JFrame
 		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyTargetNotesRandomizeOnCompose);
 		melodySettingsExtraPanelBlocksPatternsCompose.add(new JLabel("Pattern Effect"));
 		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyPatternEffect);
-		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyPatternFlexible);
 		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyPatternRandomizeOnCompose);
 		JPanel postProcessPanel = new JPanel();
 		postProcessPanel.setBorder(BorderFactory.createBevelBorder(BevelBorder.LOWERED));
@@ -8095,7 +8092,6 @@ public class VibeComposerGUI extends JFrame
 		gc.setMelodyAvoidChordJumps(melodyAvoidChordJumps.isSelected());
 		gc.setMelodyBlockTargetMode(melodyBlockTargetMode.getSelectedIndex());
 		gc.setMelodyPatternEffect(melodyPatternEffect.getSelectedIndex());
-		gc.setMelodyPatternFlexible(melodyPatternFlexible.isSelected());
 		gc.setMelodyRhythmAccents(melodyRhythmAccents.getSelectedIndex());
 		gc.setMelodyRhythmAccentsMode(melodyRhythmAccentsMode.getSelectedIndex());
 		gc.setMelodyRhythmAccentsPocket(melodyRhythmAccentsPocket.isSelected());
@@ -8233,7 +8229,6 @@ public class VibeComposerGUI extends JFrame
 		melodyUseDirectionsFromProgression.setSelected(gc.isMelodyUseDirectionsFromProgression());
 		melodyBlockTargetMode.setSelectedIndex(gc.getMelodyBlockTargetMode());
 		melodyPatternEffect.setSelectedIndex(gc.getMelodyPatternEffect());
-		melodyPatternFlexible.setSelected(gc.isMelodyPatternFlexible());
 		melodyRhythmAccents.setSelectedIndex(gc.getMelodyRhythmAccents());
 		melodyRhythmAccentsMode.setSelectedIndex(gc.getMelodyRhythmAccentsMode());
 		melodyRhythmAccentsPocket.setSelected(gc.isMelodyRhythmAccentsPocket());

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -201,6 +201,7 @@ import org.vibehistorian.vibecomposer.Popups.AboutPopup;
 import org.vibehistorian.vibecomposer.Popups.ApplyCustomSectionPopup;
 import org.vibehistorian.vibecomposer.Popups.ArrangementGlobalVariationPopup;
 import org.vibehistorian.vibecomposer.Popups.ArrangementPartInclusionPopup;
+import org.vibehistorian.vibecomposer.Popups.ChordTransformPopup;
 import org.vibehistorian.vibecomposer.Popups.DebugConsole;
 import org.vibehistorian.vibecomposer.Popups.DrumLoopPopup;
 import org.vibehistorian.vibecomposer.Popups.ExtraSettingsPopup;
@@ -4399,6 +4400,18 @@ public class VibeComposerGUI extends JFrame
 			}
 		});
 		customChordsPanel.add(melodifyChordsButton);
+
+		JButton chordTransformButton = new JButton("T");
+		chordTransformButton.setPreferredSize(new Dimension(25, 25));
+		chordTransformButton.setMargin(new Insets(0, 0, 0, 0));
+		chordTransformButton.addActionListener(new ActionListener() {
+
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				new ChordTransformPopup(userChords.getChordListString());
+			}
+		});
+		customChordsPanel.add(chordTransformButton);
 
 		userChordsDurations = new JTextField("4,4,4,4", 9);
 		JLabel userChordsDurationsLabel = new JLabel("Chord durations:");

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -1005,10 +1005,10 @@ public class VibeComposerGUI extends JFrame
 			for (int i = 1; i < 5; i++) {
 				generatePanels(i);
 			}
+			LG.i("Panels generated at : " + (System.currentTimeMillis() - sysTime) + " ms!");
 		}
 
 		composingInProgress = false;
-		LG.i("Panels generated at : " + (System.currentTimeMillis() - sysTime) + " ms!");
 	}
 
 
@@ -1049,13 +1049,13 @@ public class VibeComposerGUI extends JFrame
 	}
 
 	private void initTitles(int startY, int anchorSide) {
-		mainTitle = new JLabel("Vibe Composer");
+		/*mainTitle = new JLabel("Vibe Composer");
 		mainTitle.setBorder(BorderFactory.createBevelBorder(BevelBorder.RAISED));
 		subTitle = new JLabel("by Vibe Historian");
 		subTitle.setBorder(BorderFactory.createBevelBorder(BevelBorder.RAISED));
-
+		
 		mainTitle.setFont(new Font("Courier", Font.BOLD, 25));
-		//subTitle.setFont(subTitle.getFont().deriveFont(Font.BOLD));
+		subTitle.setFont(subTitle.getFont().deriveFont(Font.BOLD));*/
 		constraints.weightx = 100;
 		constraints.weighty = 100;
 		constraints.gridx = 0;
@@ -5532,8 +5532,8 @@ public class VibeComposerGUI extends JFrame
 		toggledComposeColor = uiComposeTextColor();
 
 
-		mainTitle.setForeground((isDarkMode) ? new Color(0, 220, 220) : lightModeUIColor);
-		subTitle.setForeground(toggledUIColor);
+		//mainTitle.setForeground((isDarkMode) ? new Color(0, 220, 220) : lightModeUIColor);
+		//subTitle.setForeground(toggledUIColor);
 		messageLabel.setForeground(toggledUIColor);
 		tipLabel.setForeground(toggledUIColor);
 		currentTime.setForeground(toggledUIColor);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -503,6 +503,7 @@ public class VibeComposerGUI extends JFrame
 	JCheckBox melodyArpySurprises;
 	JCheckBox melodySingleNoteExceptions;
 	JCheckBox melodyFillPausesPerChord;
+	KnobPanel melodyNewBlocksChance;
 	JCheckBox melodyLegacyMode;
 
 	JCheckBox melodyAvoidChordJumps;
@@ -1909,6 +1910,7 @@ public class VibeComposerGUI extends JFrame
 				true);
 		melodyFillPausesPerChord = new CustomCheckBox("<html>Fill Pauses<br>Per Chord</html>",
 				true);
+		melodyNewBlocksChance = new KnobPanel("New<br>Blocks%", 25);
 		melodyLegacyMode = new CustomCheckBox("<html>LEGACY<br>MODE</html>", false);
 		melodyAvoidChordJumps = new CustomCheckBox("<html>Avoid<br>Chord Jumps</html>", true);
 		melodyUseDirectionsFromProgression = new CustomCheckBox(
@@ -1950,6 +1952,7 @@ public class VibeComposerGUI extends JFrame
 		melodySettingsExtraPanelShape.add(melodyArpySurprises);
 		melodySettingsExtraPanelShape.add(melodySingleNoteExceptions);
 		melodySettingsExtraPanelShape.add(melodyFillPausesPerChord);
+		melodySettingsExtraPanelShape.add(melodyNewBlocksChance);
 		melodySettingsExtraPanelShape.add(melodyLegacyMode);
 		return melodySettingsExtraPanelShape;
 	}
@@ -8163,6 +8166,7 @@ public class VibeComposerGUI extends JFrame
 		gc.setMelodySingleNoteExceptions(melodySingleNoteExceptions.isSelected());
 		gc.setMelodyFillPausesPerChord(melodyFillPausesPerChord.isSelected());
 		gc.setMelodyLegacyMode(melodyLegacyMode.isSelected());
+		gc.setMelodyNewBlocksChance(melodyNewBlocksChance.getInt());
 		gc.setMelodyUseDirectionsFromProgression(melodyUseDirectionsFromProgression.isSelected());
 		gc.setMelodyAvoidChordJumps(melodyAvoidChordJumps.isSelected());
 		gc.setMelodyBlockTargetMode(melodyBlockTargetMode.getSelectedIndex());
@@ -8300,6 +8304,7 @@ public class VibeComposerGUI extends JFrame
 		melodySingleNoteExceptions.setSelected(gc.isMelodySingleNoteExceptions());
 		melodyFillPausesPerChord.setSelected(gc.isMelodyFillPausesPerChord());
 		melodyLegacyMode.setSelected(gc.isMelodyLegacyMode());
+		melodyNewBlocksChance.setInt(gc.getMelodyNewBlocksChance());
 		melodyAvoidChordJumps.setSelected(gc.isMelodyAvoidChordJumps());
 		melodyUseDirectionsFromProgression.setSelected(gc.isMelodyUseDirectionsFromProgression());
 		melodyBlockTargetMode.setSelectedIndex(gc.getMelodyBlockTargetMode());

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -279,7 +279,7 @@ public class VibeComposerGUI extends JFrame
 	public static Color panelColorHigh, panelColorLow;
 	public static boolean isBigMonitorMode = false;
 	public static boolean isDarkMode = true;
-	private static boolean isFullMode = true;
+	private static boolean isFullMode = false;
 	public static Color darkModeUIColor = Color.CYAN;
 	public static Color lightModeUIColor = new Color(0, 90, 255);
 	public static final Color COMPOSE_COLOR = new Color(180, 150, 90);
@@ -4558,6 +4558,10 @@ public class VibeComposerGUI extends JFrame
 		toggleableComponents.add(dotdotChordsButton);
 		toggleableComponents.add(ddChordsButton);
 		toggleableComponents.add(normalizeChordsButton);
+		toggleableComponents.add(ivChordsButton);
+		toggleableComponents.add(limitChordsButton);
+		toggleableComponents.add(melodifyChordsButton);
+		toggleableComponents.add(chordTransformButton);
 
 	}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -1285,7 +1285,6 @@ public class VibeComposerGUI extends JFrame
 
 		JPanel composeSettingsPanel = new JPanel();
 		JPanel scoreMidiPanel = new JPanel();
-		JPanel scalePanel = new JPanel();
 		JPanel panelGenerationSettingsPanel = new JPanel();
 		JPanel chordChoicePanel = new JPanel();
 		JPanel humanizationPanel = new JPanel();
@@ -1297,7 +1296,6 @@ public class VibeComposerGUI extends JFrame
 		HashMap<String, JPanel> settingsMenuItems = new LinkedHashMap<>();
 		settingsMenuItems.put("COMPOSE", composeSettingsPanel);
 		settingsMenuItems.put("Score/Midi", scoreMidiPanel);
-		settingsMenuItems.put("Scale", scalePanel);
 		settingsMenuItems.put("Generation", panelGenerationSettingsPanel);
 		settingsMenuItems.put("Chords", chordChoicePanel);
 		settingsMenuItems.put("Humanization", humanizationPanel);
@@ -1320,7 +1318,7 @@ public class VibeComposerGUI extends JFrame
 		extraSettingsPanel.add(titlePanel, BorderLayout.NORTH);
 		extraSettingsPanel.add(sidePanel, BorderLayout.WEST);
 		extraSettingsPanel.add(viewPanel, BorderLayout.CENTER);
-		extraSettingsPanel.setPreferredSize(new Dimension(800, 600));
+		extraSettingsPanel.setPreferredSize(new Dimension(800, 500));
 
 		// default on first open
 		currentSettingsMenuPanel = composeSettingsPanel;
@@ -1383,12 +1381,6 @@ public class VibeComposerGUI extends JFrame
 		swingMultiPanel.add(swingUnitMultiplier);
 		humanizationPanel.add(swingMultiPanel);
 
-
-		// SCALE
-		customMidiForceScale = new CustomCheckBox("Force MIDI Melody Notes To Scale", false);
-		transposedNotesForceScale = new CustomCheckBox("Force Transposed Notes To Scale", false);
-		scalePanel.add(customMidiForceScale);
-		scalePanel.add(transposedNotesForceScale);
 
 		// SCORE
 		JPanel padMidiPanel = new JPanel();
@@ -1508,16 +1500,6 @@ public class VibeComposerGUI extends JFrame
 		pauseBehaviorPanel.add(moveStartToCustomizedSection);
 
 		// CHORDS
-		JPanel keyChangePanel = new JPanel();
-		keyChangePanel.setLayout(new GridLayout(0, 2, 10, 30));
-		keyChangeTypeSelection = new ScrollComboBox<String>(false);
-		ScrollComboBox.addAll(new String[] { "PIVOT", "TWOFIVEONE", "DIRECT" },
-				keyChangeTypeSelection);
-		keyChangeTypeSelection.setVal("TWOFIVEONE");
-		keyChangeTypeSelection.addItemListener(this);
-		keyChangePanel.add(new JLabel("<html>Key Change<br>Type:</html>"));
-		keyChangePanel.add(keyChangeTypeSelection);
-
 		spiceFlattenBigChords = new CustomCheckBox("Spicy Voicing", false);
 		useChordFormula = new CustomCheckBox("Chord Formula", true);
 		randomChordVoicingChance = new KnobPanel("Flatten<br>Voicing%", 100);
@@ -1530,7 +1512,6 @@ public class VibeComposerGUI extends JFrame
 		chordChoicePanel.add(randomChordVoicingChance);
 		chordChoicePanel.add(spiceFlattenBigChords);
 		chordChoicePanel.add(squishChordsProgressively);
-		chordChoicePanel.add(keyChangePanel);
 
 		// BPM
 		arpAffectsBpm = new CustomCheckBox("BPM slowed by ARP", false);
@@ -1608,16 +1589,35 @@ public class VibeComposerGUI extends JFrame
 
 		// GENERATION
 
+		//          scale
+		customMidiForceScale = new CustomCheckBox("Force MIDI Melody Notes To Scale", false);
+		transposedNotesForceScale = new CustomCheckBox("Force Transposed Notes To Scale", false);
+
 		orderedTransposeGeneration = new CustomCheckBox("Ordered Transpose Generation", false);
 		configHistoryStoreRegeneratedTracks = new CustomCheckBox(
 				"Track History - Include Regenerated Tracks", false);
 		melodyPatternFlip = new CustomCheckBox("Inverse Melody1 Pattern", false);
 		patternApplyPausesWhenGenerating = new CustomCheckBox("Apply Pause% on Generate", true);
 
+
+		JPanel keyChangePanel = new JPanel();
+		keyChangePanel.setLayout(new GridLayout(0, 2, 10, 30));
+		keyChangeTypeSelection = new ScrollComboBox<String>(false);
+		ScrollComboBox.addAll(new String[] { "PIVOT", "TWOFIVEONE", "DIRECT" },
+				keyChangeTypeSelection);
+		keyChangeTypeSelection.setVal("TWOFIVEONE");
+		keyChangeTypeSelection.setPreferredSize(new Dimension(250, 30));
+		keyChangeTypeSelection.addItemListener(this);
+		keyChangePanel.add(new JLabel("<html>Key Change<br>Type:</html>"));
+		keyChangePanel.add(keyChangeTypeSelection);
+
+		panelGenerationSettingsPanel.add(customMidiForceScale);
+		panelGenerationSettingsPanel.add(transposedNotesForceScale);
 		panelGenerationSettingsPanel.add(orderedTransposeGeneration);
 		panelGenerationSettingsPanel.add(configHistoryStoreRegeneratedTracks);
 		panelGenerationSettingsPanel.add(melodyPatternFlip);
 		panelGenerationSettingsPanel.add(patternApplyPausesWhenGenerating);
+		panelGenerationSettingsPanel.add(keyChangePanel);
 
 		initHelperPopups();
 	}

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -145,6 +145,7 @@ import org.vibehistorian.vibecomposer.InstUtils.POOL;
 import org.vibehistorian.vibecomposer.MidiUtils.ScaleMode;
 import org.vibehistorian.vibecomposer.Section.SectionType;
 import org.vibehistorian.vibecomposer.Components.CheckButton;
+import org.vibehistorian.vibecomposer.Components.Chordlet;
 import org.vibehistorian.vibecomposer.Components.CollectionCellRenderer;
 import org.vibehistorian.vibecomposer.Components.CustomCheckBox;
 import org.vibehistorian.vibecomposer.Components.DynamicGridLayout;
@@ -4283,16 +4284,15 @@ public class VibeComposerGUI extends JFrame
 
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				Pair<List<String>, List<Double>> normalizedChords = solveUserChords(
-						userChords.getChordListString(), userChordsDurations.getText());
-				if (normalizedChords != null) {
-					List<String> chords = normalizedChords.getLeft();
-					List<String> chords2x = new ArrayList<>(chords);
-					chords.forEach(ch -> {
-						chords2x.add(ch);
-					});
-					userChords.setupChords(chords2x);
+				if (userChords.chordCount() < 1) {
+					return;
 				}
+				List<String> chords = userChords.getChordList();
+				List<String> chords2x = new ArrayList<>(chords);
+				chords.forEach(ch -> {
+					chords2x.add(ch);
+				});
+				userChords.setupChords(chords2x);
 			}
 		});
 		customChordsPanel.add(twoExChordsButton);
@@ -4304,17 +4304,16 @@ public class VibeComposerGUI extends JFrame
 
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				Pair<List<String>, List<Double>> normalizedChords = solveUserChords(
-						userChords.getChordListString(), userChordsDurations.getText());
-				if (normalizedChords != null) {
-					List<String> chords = normalizedChords.getLeft();
-					List<String> chordsDd = new ArrayList<>();
-					chords.forEach(ch -> {
-						chordsDd.add(ch);
-						chordsDd.add(ch);
-					});
-					userChords.setupChords(chordsDd);
+				if (userChords.chordCount() < 1) {
+					return;
 				}
+				List<String> chords = userChords.getChordList();
+				List<String> chordsDd = new ArrayList<>();
+				chords.forEach(ch -> {
+					chordsDd.add(ch);
+					chordsDd.add(ch);
+				});
+				userChords.setupChords(chordsDd);
 			}
 		});
 		customChordsPanel.add(ddChordsButton);
@@ -4326,16 +4325,17 @@ public class VibeComposerGUI extends JFrame
 
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				Pair<List<String>, List<Double>> normalizedChords = solveUserChords(
-						userChords.getChordListString(), userChordsDurations.getText());
-				if (normalizedChords != null) {
-					List<String> chords = normalizedChords.getLeft();
-					List<String> chordsDotDot = new ArrayList<>();
-					chords.forEach(ch -> {
-						chordsDotDot.add(MidiUtils.makeSpelledChord(MidiUtils.mappedChord(ch)));
-					});
-					userChords.setupChords(chordsDotDot);
+				if (userChords.chordCount() < 1) {
+					return;
 				}
+				List<Chordlet> chordlets = userChords.getChordlets();
+				List<String> chordsDotDot = new ArrayList<>();
+				chordlets.forEach(ch -> {
+					chordsDotDot.add(MidiUtils
+							.makeSpelledChord(MidiUtils.mappedChord(ch.getChordText(), true))
+							+ ch.getInversionText());
+				});
+				userChords.setupChords(chordsDotDot);
 			}
 		});
 		customChordsPanel.add(dotdotChordsButton);
@@ -4347,17 +4347,17 @@ public class VibeComposerGUI extends JFrame
 
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				Pair<List<String>, List<Double>> normalizedChords = solveUserChords(
-						userChords.getChordListString(), userChordsDurations.getText());
-				if (normalizedChords != null) {
-					List<String> chords = normalizedChords.getLeft();
-					List<String> chordStrings = new ArrayList<>();
-					chords.forEach(ch -> {
-						chordStrings
-								.add(MidiUtils.chordStringFromPitches(MidiUtils.mappedChord(ch)));
-					});
-					userChords.setupChords(chordStrings);
+				if (userChords.chordCount() < 1) {
+					return;
 				}
+				List<Chordlet> chordlets = userChords.getChordlets();
+				List<String> chordStrings = new ArrayList<>();
+				chordlets.forEach(ch -> {
+					chordStrings.add(MidiUtils
+							.chordStringFromPitches(MidiUtils.mappedChord(ch.getChordText(), true))
+							+ ch.getInversionText());
+				});
+				userChords.setupChords(chordStrings);
 			}
 		});
 		customChordsPanel.add(ivChordsButton);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -19,6 +19,7 @@ see <https://www.gnu.org/licenses/>.
 
 package org.vibehistorian.vibecomposer;
 
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
@@ -74,6 +75,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -725,6 +727,7 @@ public class VibeComposerGUI extends JFrame
 	private static GridBagConstraints constraints = new GridBagConstraints();
 
 	public static JPanel extraSettingsPanel;
+	public static JPanel currentSettingsMenuPanel = null;
 
 	public static boolean isShowingTextInKnobs = true;
 	public static JCheckBox displayVeloRectValues;
@@ -1106,7 +1109,7 @@ public class VibeComposerGUI extends JFrame
 
 
 		extraSettingsPanel = new JPanel();
-		extraSettingsPanel.setLayout(new BoxLayout(extraSettingsPanel, BoxLayout.Y_AXIS));
+		extraSettingsPanel.setLayout(new BorderLayout());
 
 		mainButtonsPanel.add(makeButton("Settings", e -> openExtraSettingsPopup()));
 
@@ -1278,90 +1281,169 @@ public class VibeComposerGUI extends JFrame
 	}
 
 	private void initExtraSettings() {
-		JPanel arrangementExtraSettingsPanel = new JPanel();
-		arrangementExtraSettingsPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
-		arrangementScaleMidiVelocity = new CustomCheckBox("Scale Midi Velocity in Arrangement",
-				true);
+
+		JPanel composeSettingsPanel = new JPanel();
+		JPanel scoreMidiPanel = new JPanel();
+		JPanel scalePanel = new JPanel();
+		JPanel panelGenerationSettingsPanel = new JPanel();
+		JPanel chordChoicePanel = new JPanel();
+		JPanel humanizationPanel = new JPanel();
+		JPanel instrumentsSettingsPanel = new JPanel();
+		JPanel pauseBehaviorPanel = new JPanel();
+		JPanel bpmLowHighPanel = new JPanel();
+		JPanel displayStylePanel = new JPanel();
+
+		HashMap<String, JPanel> settingsMenuItems = new LinkedHashMap<>();
+		settingsMenuItems.put("COMPOSE", composeSettingsPanel);
+		settingsMenuItems.put("Score/Midi", scoreMidiPanel);
+		settingsMenuItems.put("Scale", scalePanel);
+		settingsMenuItems.put("Generation", panelGenerationSettingsPanel);
+		settingsMenuItems.put("Chords", chordChoicePanel);
+		settingsMenuItems.put("Humanization", humanizationPanel);
+		settingsMenuItems.put("Instruments", instrumentsSettingsPanel);
+
+		settingsMenuItems.put("Pause Behavior", pauseBehaviorPanel);
+		settingsMenuItems.put("BPM", bpmLowHighPanel);
+		settingsMenuItems.put("Display", displayStylePanel);
+
+		JPanel sidePanel = new JPanel();
+		sidePanel.setLayout(new GridLayout(0, 1, 10, 10));
+		JPanel viewPanel = new JPanel();
+		viewPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
+		viewPanel.setAlignmentX(JPanel.LEFT_ALIGNMENT);
+		JPanel titlePanel = new JPanel();
+		titlePanel.setBorder(new SoftBevelBorder(BevelBorder.RAISED));
+		JLabel settingsMenuTitle = new JLabel();
+		titlePanel.add(settingsMenuTitle);
+
+		extraSettingsPanel.add(titlePanel, BorderLayout.NORTH);
+		extraSettingsPanel.add(sidePanel, BorderLayout.WEST);
+		extraSettingsPanel.add(viewPanel, BorderLayout.CENTER);
+		extraSettingsPanel.setPreferredSize(new Dimension(800, 600));
+
+		// default on first open
+		currentSettingsMenuPanel = composeSettingsPanel;
+		viewPanel.add(currentSettingsMenuPanel);
+		settingsMenuTitle.setText("COMPOSE");
+
+		for (Map.Entry<String, JPanel> entry : settingsMenuItems.entrySet()) {
+			String buttonName = entry.getKey();
+			JPanel menuPanel = entry.getValue();
+			menuPanel.setLayout(new GridLayout(0, 1, 20, 20));
+			JButton butt = makeButton(buttonName, e -> {
+				if (currentSettingsMenuPanel != null) {
+					//viewPanel.remove(currentSettingsMenuPanel);
+					currentSettingsMenuPanel.setVisible(false);
+				}
+				currentSettingsMenuPanel = menuPanel;
+				currentSettingsMenuPanel.setVisible(true);
+				viewPanel.add(currentSettingsMenuPanel);
+				settingsMenuTitle.setText(buttonName);
+
+				viewPanel.repaint();
+			});
+
+			sidePanel.add(butt);
+		}
+
+		// COMPOSE
+
 		arrangementResetCustomPanelsOnCompose = makeCheckBox("Reset Customized Panels on Compose",
 				true, true);
-
-		useMidiCC = new CustomCheckBox("Use Volume/Pan/Reverb/Chorus/Filter/.. MIDI CC", true);
-		useMidiCC.setToolTipText("Volume - 7, Reverb - 91, Chorus - 93, Filter - 74");
-		//RandomIntegerListButton bt = new RandomIntegerListButton("0,1,2,3");
-		arrangementExtraSettingsPanel.add(arrangementScaleMidiVelocity);
-		arrangementExtraSettingsPanel.add(useMidiCC);
-		arrangementExtraSettingsPanel.add(arrangementResetCustomPanelsOnCompose);
-		//arrangementExtraSettingsPanel.add(bt);
-
-		JPanel humanizationPanel = new JPanel();
-		humanizationPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
-
-		// / 10000
-		humanizeNotes = new DetachedKnobPanel("Humanize Notes<br>/10000", 150, 0, 1000);
-		// / 10000
-		humanizeDrums = new DetachedKnobPanel("Humanize Drums<br>/10000", 20, 0, 100);
-
-		// / 1000
-		globalNoteLengthMultiplier = new DetachedKnobPanel("Note Length Multiplier<br>/1000", 950,
-				250, 1000);
-
-		swingUnitMultiplier = new ScrollComboBox<Double>(false);
-		ScrollComboBox.addAll(new Double[] { 0.5, 1.0, 2.0 }, swingUnitMultiplier);
-		swingUnitMultiplier.setSelectedIndex(0);
-
 		randomizeTimingsOnCompose = makeCheckBox(
 				"<html>Randomize Global Swing/Beat Multiplier<br>on Compose</html>", true, true);
 		sidechainPatternsOnCompose = makeCheckBox("<html>Sidechain Patterns<br>on Compose</html>",
 				true, true);
+		copyChordsAfterGenerate = makeCheckBox("<html>Copy Chords<br>on Compose/Reg.</html>", true,
+				true);
+
+		composeSettingsPanel.add(arrangementResetCustomPanelsOnCompose);
+		composeSettingsPanel.add(randomizeTimingsOnCompose);
+		composeSettingsPanel.add(sidechainPatternsOnCompose);
+		composeSettingsPanel.add(copyChordsAfterGenerate);
+
+
+		// HUMANIZATION
+		humanizeNotes = new DetachedKnobPanel("Humanize Notes<br>/10000", 150, 0, 1000);
+		humanizeDrums = new DetachedKnobPanel("Humanize Drums<br>/10000", 20, 0, 100);
+		globalNoteLengthMultiplier = new DetachedKnobPanel("Note Length Multiplier<br>/1000", 950,
+				250, 1000);
+
+		JPanel swingMultiPanel = new JPanel();
+		swingMultiPanel.setLayout(new GridLayout(0, 2, 10, 30));
+		swingUnitMultiplier = new ScrollComboBox<Double>(false);
+		ScrollComboBox.addAll(new Double[] { 0.5, 1.0, 2.0 }, swingUnitMultiplier);
+		swingUnitMultiplier.setSelectedIndex(0);
 
 		humanizationPanel.add(humanizeNotes);
 		humanizationPanel.add(humanizeDrums);
 		humanizationPanel.add(globalNoteLengthMultiplier);
-		humanizationPanel.add(new JLabel("Swing Period Multiplier"));
-		humanizationPanel.add(swingUnitMultiplier);
-		humanizationPanel.add(randomizeTimingsOnCompose);
-		humanizationPanel.add(sidechainPatternsOnCompose);
+		swingMultiPanel.add(new JLabel("Swing Period Multiplier"));
+		swingMultiPanel.add(swingUnitMultiplier);
+		humanizationPanel.add(swingMultiPanel);
 
-		JPanel scalePanel = new JPanel();
-		scalePanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
+
+		// SCALE
 		customMidiForceScale = new CustomCheckBox("Force MIDI Melody Notes To Scale", false);
 		transposedNotesForceScale = new CustomCheckBox("Force Transposed Notes To Scale", false);
 		scalePanel.add(customMidiForceScale);
 		scalePanel.add(transposedNotesForceScale);
 
-		JPanel scoreMidiPanel = new JPanel();
-		scoreMidiPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
+		// SCORE
+		JPanel padMidiPanel = new JPanel();
+		padMidiPanel.setLayout(new GridLayout(0, 2, 10, 30));
 		padGeneratedMidi = new CustomCheckBox("Pad Generated .mid File (# of tracks):", true);
 		padGeneratedMidiValues = new RandomIntegerListButton("3,2,5,5,6", null);
 		padGeneratedMidiValues.min = 1;
 		padGeneratedMidiValues.max = 12;
 		padGeneratedMidiValues.editableCount = false;
+		padMidiPanel.add(padGeneratedMidi);
+		padMidiPanel.add(padGeneratedMidiValues);
 
-		scoreMidiPanel.add(padGeneratedMidi);
-		scoreMidiPanel.add(padGeneratedMidiValues);
+		//                stretch
+		stretchMidi = new DetachedKnobPanel("Stretch MIDI%:", 100, 25, 400);
+		stretchMidi.getKnob().setTickSpacing(25);
+		stretchMidi.getKnob().setTickThresholds(
+				Arrays.asList(new Integer[] { 25, 50, 100, 150, 200, 300, 400 }));
 
-		extraSettingsPanel.add(arrangementExtraSettingsPanel);
-		extraSettingsPanel.add(humanizationPanel);
-		extraSettingsPanel.add(scalePanel);
-		extraSettingsPanel.add(scoreMidiPanel);
+		//                  arrangement midi settings
+		arrangementScaleMidiVelocity = new CustomCheckBox("Scale Midi Velocity in Arrangement",
+				true);
+		useMidiCC = new CustomCheckBox("Use Volume/Pan/Reverb/Chorus/Filter/.. MIDI CC", true);
+		useMidiCC.setToolTipText("Volume - 7, Reverb - 91, Chorus - 93, Filter - 74");
 
-		//JPanel loopBeatExtraSettingsPanel = new JPanel();arrangementExtraSettingsPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
-		//loopBeatExtraSettingsPanel.add(loopBeatCompose);
-		//extraSettingsPanel.add(loopBeatExtraSettingsPanel);
+		//                 drum mapping
+		JPanel drumMappingPanel = new JPanel();
+		drumMappingPanel.setLayout(new GridLayout(0, 2, 10, 30));
+		drumCustomMapping = new CustomCheckBox("Custom Drum Mapping", true);
+		drumCustomMapping.setToolTipText(
+				"<html>" + StringUtils.join(InstUtils.DRUM_INST_NAMES_SEMI, "|") + "</html>");
+		drumCustomMappingNumbers = new JTextField(
+				StringUtils.join(InstUtils.DRUM_INST_NUMBERS_SEMI, ","));
+		drumMappingPanel.add(drumCustomMapping);
+		drumMappingPanel.add(drumCustomMappingNumbers);
 
+		scoreMidiPanel.add(padMidiPanel);
+		scoreMidiPanel.add(drumMappingPanel);
+		scoreMidiPanel.add(useMidiCC);
+		scoreMidiPanel.add(stretchMidi);
+		scoreMidiPanel.add(arrangementScaleMidiVelocity);
+
+		// INSTRUMENTS
 		JPanel allInstsPanel = new JPanel();
-		allInstsPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
+
+		drumMappingPanel.setLayout(new GridLayout(0, 3, 10, 30));
 		useAllInsts = new CustomCheckBox("Use All Inst., Except:", false);
 		allInstsPanel.add(useAllInsts);
 		bannedInsts = new JTextField("", 8);
 		allInstsPanel.add(bannedInsts);
 		reinitInstPools = makeButton("Initialize All Inst.", "InitAllInsts");
 		allInstsPanel.add(reinitInstPools);
-		extraSettingsPanel.add(allInstsPanel);
+		instrumentsSettingsPanel.add(allInstsPanel);
 
-
-		JPanel pauseBehaviorPanel = new JPanel();
-		pauseBehaviorPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
+		// PAUSE
+		JPanel startFromPausePanel = new JPanel();
+		drumMappingPanel.setLayout(new GridLayout(0, 2, 10, 30));
 		pauseBehaviorLabel = new JLabel("Start From Pause:");
 		pauseBehaviorCombobox = new ScrollComboBox<>(false);
 		startFromBar = new CustomCheckBox("Start From Bar", true);
@@ -1381,78 +1463,48 @@ public class VibeComposerGUI extends JFrame
 		});
 		ScrollComboBox.addAll(new String[] { "On regenerate", "On compose/regenerate", "Never" },
 				pauseBehaviorCombobox);
-		pauseBehaviorPanel.add(pauseBehaviorLabel);
-		pauseBehaviorPanel.add(pauseBehaviorCombobox);
+		startFromPausePanel.add(pauseBehaviorLabel);
+		startFromPausePanel.add(pauseBehaviorCombobox);
+		pauseBehaviorPanel.add(startFromPausePanel);
 		pauseBehaviorPanel.add(startFromBar);
 		pauseBehaviorPanel.add(rememberLastPos);
 		pauseBehaviorPanel.add(snapStartToBeat);
 		pauseBehaviorPanel.add(moveStartToCustomizedSection);
 
-		JPanel customDrumMappingPanel = new JPanel();
-		customDrumMappingPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
-		drumCustomMapping = new CustomCheckBox("Custom Drum Mapping", true);
-		drumCustomMappingNumbers = new JTextField(
-				StringUtils.join(InstUtils.DRUM_INST_NUMBERS_SEMI, ","));
-		melodyPatternFlip = new CustomCheckBox("Inverse Melody1 Pattern", false);
-		patternApplyPausesWhenGenerating = new CustomCheckBox("Apply Pause% on Generate", true);
-
-		customDrumMappingPanel.add(drumCustomMapping);
-		customDrumMappingPanel.add(drumCustomMappingNumbers);
-		customDrumMappingPanel.add(melodyPatternFlip);
-		customDrumMappingPanel.add(patternApplyPausesWhenGenerating);
-		drumCustomMapping.setToolTipText(
-				"<html>" + StringUtils.join(InstUtils.DRUM_INST_NAMES_SEMI, "|") + "</html>");
-
-		extraSettingsPanel.add(pauseBehaviorPanel);
-		extraSettingsPanel.add(customDrumMappingPanel);
-
-
-		// CHORD SETTINGS 2
+		// CHORDS
+		JPanel keyChangePanel = new JPanel();
+		keyChangePanel.setLayout(new GridLayout(0, 2, 10, 30));
 		keyChangeTypeSelection = new ScrollComboBox<String>(false);
 		ScrollComboBox.addAll(new String[] { "PIVOT", "TWOFIVEONE", "DIRECT" },
 				keyChangeTypeSelection);
 		keyChangeTypeSelection.setVal("TWOFIVEONE");
 		keyChangeTypeSelection.addItemListener(this);
+		keyChangePanel.add(new JLabel("<html>Key Change<br>Type:</html>"));
+		keyChangePanel.add(keyChangeTypeSelection);
 
-		JPanel chordChoicePanel = new JPanel();
-		chordChoicePanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 		spiceFlattenBigChords = new CustomCheckBox("Spicy Voicing", false);
 		useChordFormula = new CustomCheckBox("Chord Formula", true);
 		randomChordVoicingChance = new KnobPanel("Flatten<br>Voicing%", 100);
 		squishChordsProgressively = new CustomCheckBox("<html>Flatten<br>Progressively</html>",
 				false);
-		copyChordsAfterGenerate = makeCheckBox("<html>Copy Chords<br>on Compose/Reg.</html>", true,
-				true);
 		longProgressionSimilarity = new DetachedKnobPanel("8 Chords <br>Similarity%", 50, 0, 100);
-
 
 		chordChoicePanel.add(useChordFormula);
 		chordChoicePanel.add(longProgressionSimilarity);
 		chordChoicePanel.add(randomChordVoicingChance);
 		chordChoicePanel.add(spiceFlattenBigChords);
 		chordChoicePanel.add(squishChordsProgressively);
-		chordChoicePanel.add(copyChordsAfterGenerate);
-		chordChoicePanel.add(new JLabel("<html>Key Change<br>Type:</html>"));
-		chordChoicePanel.add(keyChangeTypeSelection);
-		extraSettingsPanel.add(chordChoicePanel);
+		chordChoicePanel.add(keyChangePanel);
 
-		JPanel bpmLowHighPanel = new JPanel();
-		bpmLowHighPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
-
+		// BPM
 		arpAffectsBpm = new CustomCheckBox("BPM slowed by ARP", false);
 		bpmLow = new DetachedKnobPanel("Min<br>BPM.", 50, 20, 249);
 		bpmHigh = new DetachedKnobPanel("Max<br>BPM.", 95, 21, 250);
-		stretchMidi = new DetachedKnobPanel("Stretch MIDI%:", 100, 25, 400);
-		stretchMidi.getKnob().setTickSpacing(25);
-		stretchMidi.getKnob().setTickThresholds(
-				Arrays.asList(new Integer[] { 25, 50, 100, 150, 200, 300, 400 }));
 		bpmLowHighPanel.add(bpmLow);
 		bpmLowHighPanel.add(bpmHigh);
 		bpmLowHighPanel.add(arpAffectsBpm);
-		bpmLowHighPanel.add(stretchMidi);
 
-		extraSettingsPanel.add(bpmLowHighPanel);
-
+		// SOUNDBANK
 		soundbankFilename = new ScrollComboBox<String>(false);
 		soundbankFilename.setEditable(true);
 		soundbankFilename.addItem(OMNI.EMPTYCOMBO);
@@ -1476,15 +1528,15 @@ public class VibeComposerGUI extends JFrame
 				needSoundbankRefresh = true;
 			}
 		});
+
 		JPanel soundbankPanel = new JPanel();
-		soundbankPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
+		soundbankPanel.setLayout(new GridLayout(0, 2, 10, 30));
 		JLabel soundbankLabel = new JLabel("Soundbank name:");
 		soundbankPanel.add(soundbankLabel);
 		soundbankPanel.add(soundbankFilename);
-		extraSettingsPanel.add(soundbankPanel);
+		instrumentsSettingsPanel.add(soundbankPanel);
 
-		JPanel displayStylePanel = new JPanel();
-		displayStylePanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
+		// DISPLAY
 		displayVeloRectValues = new CustomCheckBox("Display Bar Values", true);
 		knobControlByDragging = new CustomCheckBox("Knob Up-Down Control", false);
 		highlightPatterns = new CustomCheckBox("Highlight Sequencer Pattern (-Perf)", true);
@@ -1516,18 +1568,8 @@ public class VibeComposerGUI extends JFrame
 			}
 
 		});
-		displayStylePanel.add(checkbutt);
-		displayStylePanel.add(displayVeloRectValues);
-		displayStylePanel.add(knobControlByDragging);
-		displayStylePanel.add(highlightPatterns);
-		displayStylePanel.add(highlightScoreNotes);
-		displayStylePanel.add(customFilenameAddTimestamp);
-		displayStylePanel.add(miniScorePopup);
-		extraSettingsPanel.add(displayStylePanel);
 
 
-		JPanel panelGenerationSettingsPanel = new JPanel();
-		panelGenerationSettingsPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 		bottomUpReverseDrumPanels = new CustomCheckBox("Bottom-Top Drum Display", false);
 		bottomUpReverseDrumPanels.addChangeListener(new ChangeListener() {
 
@@ -1551,14 +1593,27 @@ public class VibeComposerGUI extends JFrame
 			}
 		});
 
+		displayStylePanel.add(bottomUpReverseDrumPanels);
+		displayStylePanel.add(checkbutt);
+		displayStylePanel.add(displayVeloRectValues);
+		displayStylePanel.add(knobControlByDragging);
+		displayStylePanel.add(highlightPatterns);
+		displayStylePanel.add(highlightScoreNotes);
+		displayStylePanel.add(customFilenameAddTimestamp);
+		displayStylePanel.add(miniScorePopup);
+
+		// GENERATION
+
 		orderedTransposeGeneration = new CustomCheckBox("Ordered Transpose Generation", false);
 		configHistoryStoreRegeneratedTracks = new CustomCheckBox(
 				"Track History - Include Regenerated Tracks", false);
+		melodyPatternFlip = new CustomCheckBox("Inverse Melody1 Pattern", false);
+		patternApplyPausesWhenGenerating = new CustomCheckBox("Apply Pause% on Generate", true);
 
-		panelGenerationSettingsPanel.add(bottomUpReverseDrumPanels);
 		panelGenerationSettingsPanel.add(orderedTransposeGeneration);
 		panelGenerationSettingsPanel.add(configHistoryStoreRegeneratedTracks);
-		extraSettingsPanel.add(panelGenerationSettingsPanel);
+		panelGenerationSettingsPanel.add(melodyPatternFlip);
+		panelGenerationSettingsPanel.add(patternApplyPausesWhenGenerating);
 
 		initHelperPopups();
 	}
@@ -5295,7 +5350,7 @@ public class VibeComposerGUI extends JFrame
 		helperPopupsPanel.add(makeButton("User Manual (opens browser)", e -> openHelpPopup()));
 		helperPopupsPanel.add(makeButton("Debug Console", e -> openDebugConsole()));
 		helperPopupsPanel.add(makeButton("About VibeComposer", e -> openAboutPopup()));
-		extraSettingsPanel.add(helperPopupsPanel);
+		extraSettingsPanel.add(helperPopupsPanel, BorderLayout.SOUTH);
 	}
 
 	private void startMidiCcThread() {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -9090,6 +9090,9 @@ public class VibeComposerGUI extends JFrame
 				ip.setMidiChannel(2 + (ip.getPanelOrder() - 1) % 7);
 				ip.setPanByOrder(7);
 			}
+
+			ip.getComboPanel().reapplyShift();
+			ip.getComboPanel().reapplyHits();
 		}
 
 		/*if (!affectedArps.isEmpty()) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -8586,12 +8586,13 @@ public class VibeComposerGUI extends JFrame
 			if (randomizeInstOnComposeOrGen.isSelected()) {
 				ip.setInstrument(ip.getInstrumentBox().getRandomInstrument());
 			}
-			ip.setChordSpanFill(bassFills[panelGenerator.nextInt(bassFills.length)]);
-			ip.setFillFlip(false);
-			ip.setPatternSeed(seed);
-
 			int panelOrder = ip.getPanelOrder();
+
+			ip.setFillFlip(false);
+
 			if (panelOrder > 1) {
+				ip.setChordSpanFill(bassFills[panelGenerator.nextInt(bassFills.length)]);
+				ip.setPatternSeed(seed);
 				ip.setPauseChance(30 + panelGenerator.nextInt(40));
 				/*melodyPanel.toggleCombinedMelodyDisabledUI(
 						combineMelodyTracks != null && !combineMelodyTracks.isSelected());*/

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -641,8 +641,6 @@ public class VibeComposerGUI extends JFrame
 				: lastRandomSeed;
 	}
 
-	double realBpm = 60;
-
 	JList<File> generatedMidi;
 	public static Sequencer sequencer = null;
 	public static Map<Integer, List<MidiEvent>> midiEventsToRemove = new HashMap<>();
@@ -6851,7 +6849,6 @@ public class VibeComposerGUI extends JFrame
 			tabPanePossibleChange = true;
 		}
 
-		realBpm = Double.valueOf(mainBpm.getInt());
 		if (ae.getActionCommand() == "RandomizeBpm") {
 			randomizeBPM();
 		}
@@ -7161,7 +7158,6 @@ public class VibeComposerGUI extends JFrame
 		mainBpm.setInt(bpm);
 		mainBpm.getKnob().setMin(bpmLow.getInt());
 		mainBpm.getKnob().setMax(bpmHigh.getInt());
-		realBpm = bpm;
 	}
 
 	private void enthickenText(Component comp) {

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -9421,7 +9421,7 @@ public class VibeComposerGUI extends JFrame
 		}
 
 		if (drumPanels.size() > 10 && ip.getPattern() == RhythmPattern.FULL
-				&& panelGenerator.nextInt() < 30) {
+				&& panelGenerator.nextInt(100) < 30) {
 			ip.setPattern(RhythmPattern.ALT);
 		}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -4408,6 +4408,9 @@ public class VibeComposerGUI extends JFrame
 
 			@Override
 			public void actionPerformed(ActionEvent e) {
+				if (melodyPanels.isEmpty()) {
+					return;
+				}
 				userChords.alignWithMelodyTargetNotes(melodyPanels.get(0).getChordNoteChoices());
 			}
 		});
@@ -5733,7 +5736,8 @@ public class VibeComposerGUI extends JFrame
 			makeDir.mkdir();
 
 			String seedData = "" + masterpieceSeed;
-			if (melodyPanels.get(0).getPatternSeed() != 0 && !melodyPanels.get(0).getMuteInst()) {
+			if (!melodyPanels.isEmpty() && melodyPanels.get(0).getPatternSeed() != 0
+					&& !melodyPanels.get(0).getMuteInst()) {
 				seedData += "_" + melodyPanels.get(0).getPatternSeed();
 			}
 			String keyTrans = MidiUtils.SEMITONE_LETTERS.get((transposeScore.getInt() + 120) % 12)
@@ -5834,9 +5838,11 @@ public class VibeComposerGUI extends JFrame
 			MidiGenerator.RANDOMIZE_TARGET_NOTES = !regenerate
 					&& melodyTargetNotesRandomizeOnCompose.isSelected();
 			MidiGenerator.TARGET_NOTES = (melody1ForcePatterns.isSelected()
+					&& !melodyPanels.isEmpty()
 					&& !melodyPanels.get(0).getNoteTargetsButton().isEnabled())
-							? melodyPanels.stream().collect(Collectors.toMap(
-									MelodyPanel::getPanelOrder, MelodyPanel::getChordNoteChoices))
+							? melodyPanels.stream()
+									.collect(Collectors.toMap(MelodyPanel::getPanelOrder,
+											MelodyPanel::getChordNoteChoices))
 							: null;
 
 			/*boolean addStartDelay = useArrangement.isSelected() || arrangementCustom.isSelected()
@@ -5984,7 +5990,8 @@ public class VibeComposerGUI extends JFrame
 			randomizeMelodySeeds();
 		}
 
-		if (!regenerate && melodyPatternRandomizeOnCompose.isSelected()) {
+		if (!regenerate && melodyPatternRandomizeOnCompose.isSelected()
+				&& !melodyPanels.isEmpty()) {
 			if (melody1ForcePatterns.isSelected()) {
 				MelodyPanel firstMp = melodyPanels.get(0);
 				List<Integer> pat = MelodyUtils.getRandomMelodyPattern(
@@ -6001,7 +6008,7 @@ public class VibeComposerGUI extends JFrame
 		}
 
 
-		if (melody1ForcePatterns.isSelected()) {
+		if (melody1ForcePatterns.isSelected() && !melodyPanels.isEmpty()) {
 			MelodyPanel mp1 = melodyPanels.get(0);
 			for (int i = 1; i < melodyPanels.size(); i++) {
 				melodyPanels.get(i).overridePatterns(mp1);
@@ -6013,7 +6020,7 @@ public class VibeComposerGUI extends JFrame
 
 		// ARPS
 		if (instrumentTabPane.getSelectedIndex() != 3 && arpCopyMelodyInst.isSelected()
-				&& !melodyPanels.get(0).getMuteInst()) {
+				&& !melodyPanels.isEmpty() && !melodyPanels.get(0).getMuteInst()) {
 			if (arpPanels.size() > 0 && !arpPanels.get(0).getLockInst()) {
 				arpPanels.get(0).getInstrumentBox().initInstPool(POOL.MELODY);
 				arpPanels.get(0).setInstPool(POOL.MELODY);
@@ -8863,7 +8870,8 @@ public class VibeComposerGUI extends JFrame
 		int fixedInstrument = -1;
 		int fixedHits = -1;
 
-		if (arpCopyMelodyInst.isSelected() && !melodyPanels.get(0).getMuteInst()) {
+		if (arpCopyMelodyInst.isSelected() && !melodyPanels.isEmpty()
+				&& !melodyPanels.get(0).getMuteInst()) {
 			fixedInstrument = melodyPanels.get(0).getInstrument();
 			if (affectedArps.size() > 0) {
 				affectedArps.get(0).setInstrument(fixedInstrument);
@@ -8968,7 +8976,7 @@ public class VibeComposerGUI extends JFrame
 
 
 			if (first == null && panelIndex == 0 && !onlyAdd && arpCopyMelodyInst.isSelected()
-					&& !melodyPanels.get(0).getMuteInst()) {
+					&& !melodyPanels.isEmpty() && !melodyPanels.get(0).getMuteInst()) {
 				ip.setInstrument(fixedInstrument);
 			}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -26,6 +26,7 @@ import java.awt.Container;
 import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.FileDialog;
+import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.GradientPaint;
 import java.awt.Graphics;
@@ -1308,7 +1309,7 @@ public class VibeComposerGUI extends JFrame
 
 		JPanel sidePanel = new JPanel();
 		sidePanel.setLayout(new GridLayout(0, 1, 10, 10));
-		JPanel viewPanel = new JPanel();
+		JPanel viewPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
 		viewPanel.setBorder(new SoftBevelBorder(BevelBorder.LOWERED));
 		viewPanel.setAlignmentX(JPanel.LEFT_ALIGNMENT);
 		JPanel titlePanel = new JPanel();
@@ -1340,7 +1341,7 @@ public class VibeComposerGUI extends JFrame
 				viewPanel.add(currentSettingsMenuPanel);
 				settingsMenuTitle.setText(buttonName);
 
-				viewPanel.repaint();
+				SwingUtilities.updateComponentTreeUI(extraSettingsPanel);
 			});
 
 			sidePanel.add(butt);
@@ -1432,14 +1433,49 @@ public class VibeComposerGUI extends JFrame
 		// INSTRUMENTS
 		JPanel allInstsPanel = new JPanel();
 
-		drumMappingPanel.setLayout(new GridLayout(0, 3, 10, 30));
-		useAllInsts = new CustomCheckBox("Use All Inst., Except:", false);
+		allInstsPanel.setLayout(new GridLayout(0, 3, 10, 30));
+		useAllInsts = new CustomCheckBox("(Experimental) Use all Inst., except:", false);
+		useAllInsts.setHorizontalTextPosition(SwingConstants.RIGHT);
 		allInstsPanel.add(useAllInsts);
 		bannedInsts = new JTextField("", 8);
 		allInstsPanel.add(bannedInsts);
 		reinitInstPools = makeButton("Initialize All Inst.", "InitAllInsts");
 		allInstsPanel.add(reinitInstPools);
+
+		// 				soundbank
+		soundbankFilename = new ScrollComboBox<String>(false);
+		soundbankFilename.setEditable(true);
+		soundbankFilename.addItem(OMNI.EMPTYCOMBO);
+		File folder = new File(SOUNDBANK_FOLDER);
+		if (folder.exists()) {
+			File[] listOfFiles = folder.listFiles();
+			for (File f : listOfFiles) {
+				if (f.isFile()) {
+					String fileName = f.getName();
+					if (fileName.endsWith(".sf2")) {
+						soundbankFilename.addItem(fileName);
+					}
+				}
+			}
+		}
+		soundbankFilename.setVal(soundbankFilename.getLastVal());
+		soundbankFilename.addItemListener(new ItemListener() {
+
+			@Override
+			public void itemStateChanged(ItemEvent e) {
+				needSoundbankRefresh = true;
+			}
+		});
+
+		JPanel soundbankPanel = new JPanel();
+		soundbankPanel.setLayout(new GridLayout(0, 2, 10, 30));
+		JLabel soundbankLabel = new JLabel("Soundbank name:");
+		soundbankPanel.add(soundbankLabel);
+		soundbankPanel.add(soundbankFilename);
+
 		instrumentsSettingsPanel.add(allInstsPanel);
+		instrumentsSettingsPanel.add(soundbankPanel);
+
 
 		// PAUSE
 		JPanel startFromPausePanel = new JPanel();
@@ -1503,38 +1539,6 @@ public class VibeComposerGUI extends JFrame
 		bpmLowHighPanel.add(bpmLow);
 		bpmLowHighPanel.add(bpmHigh);
 		bpmLowHighPanel.add(arpAffectsBpm);
-
-		// SOUNDBANK
-		soundbankFilename = new ScrollComboBox<String>(false);
-		soundbankFilename.setEditable(true);
-		soundbankFilename.addItem(OMNI.EMPTYCOMBO);
-		File folder = new File(SOUNDBANK_FOLDER);
-		if (folder.exists()) {
-			File[] listOfFiles = folder.listFiles();
-			for (File f : listOfFiles) {
-				if (f.isFile()) {
-					String fileName = f.getName();
-					if (fileName.endsWith(".sf2")) {
-						soundbankFilename.addItem(fileName);
-					}
-				}
-			}
-		}
-		soundbankFilename.setVal(soundbankFilename.getLastVal());
-		soundbankFilename.addItemListener(new ItemListener() {
-
-			@Override
-			public void itemStateChanged(ItemEvent e) {
-				needSoundbankRefresh = true;
-			}
-		});
-
-		JPanel soundbankPanel = new JPanel();
-		soundbankPanel.setLayout(new GridLayout(0, 2, 10, 30));
-		JLabel soundbankLabel = new JLabel("Soundbank name:");
-		soundbankPanel.add(soundbankLabel);
-		soundbankPanel.add(soundbankFilename);
-		instrumentsSettingsPanel.add(soundbankPanel);
 
 		// DISPLAY
 		displayVeloRectValues = new CustomCheckBox("Display Bar Values", true);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -5307,7 +5307,7 @@ public class VibeComposerGUI extends JFrame
 	}
 
 	protected void sendPanMessage(int pan100, int channel) {
-		int value127 = useMidiCC.isSelected() ? OMNI.clampVel(pan100 * 127 / 100) : 64;
+		int value127 = useMidiCC.isSelected() ? OMNI.clampMidi(pan100 * 127 / 100) : 64;
 		sendMidiCcMessage(value127, channel, 10);
 	}
 

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -502,6 +502,7 @@ public class VibeComposerGUI extends JFrame
 	public static ScrollComboBox<String> melodyBlockTargetMode;
 	JCheckBox melodyTargetNotesRandomizeOnCompose;
 	ScrollComboBox<String> melodyPatternEffect;
+	JCheckBox melodyPatternFlexible;
 	ScrollComboBox<String> melodyRhythmAccents;
 	ScrollComboBox<String> melodyRhythmAccentsMode;
 	JCheckBox melodyRhythmAccentsPocket;
@@ -1688,6 +1689,7 @@ public class VibeComposerGUI extends JFrame
 		ScrollComboBox.addAll(new String[] { "Rhythm", "Notes", "Rhythm+Notes" },
 				melodyPatternEffect);
 		melodyPatternEffect.setSelectedIndex(2);
+		melodyPatternFlexible = makeCheckBox("Flexible", true, false);
 		melodyPatternRandomizeOnCompose = makeCheckBox(
 				"<html>Randomize Pattern<br> on Compose</html>", true, true);
 		melodyRhythmAccents = new ScrollComboBox<>();
@@ -1733,6 +1735,7 @@ public class VibeComposerGUI extends JFrame
 		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyTargetNotesRandomizeOnCompose);
 		melodySettingsExtraPanelBlocksPatternsCompose.add(new JLabel("Pattern Effect"));
 		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyPatternEffect);
+		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyPatternFlexible);
 		melodySettingsExtraPanelBlocksPatternsCompose.add(melodyPatternRandomizeOnCompose);
 		JPanel postProcessPanel = new JPanel();
 		postProcessPanel.setBorder(BorderFactory.createBevelBorder(BevelBorder.LOWERED));
@@ -8092,6 +8095,7 @@ public class VibeComposerGUI extends JFrame
 		gc.setMelodyAvoidChordJumps(melodyAvoidChordJumps.isSelected());
 		gc.setMelodyBlockTargetMode(melodyBlockTargetMode.getSelectedIndex());
 		gc.setMelodyPatternEffect(melodyPatternEffect.getSelectedIndex());
+		gc.setMelodyPatternFlexible(melodyPatternFlexible.isSelected());
 		gc.setMelodyRhythmAccents(melodyRhythmAccents.getSelectedIndex());
 		gc.setMelodyRhythmAccentsMode(melodyRhythmAccentsMode.getSelectedIndex());
 		gc.setMelodyRhythmAccentsPocket(melodyRhythmAccentsPocket.isSelected());
@@ -8229,6 +8233,7 @@ public class VibeComposerGUI extends JFrame
 		melodyUseDirectionsFromProgression.setSelected(gc.isMelodyUseDirectionsFromProgression());
 		melodyBlockTargetMode.setSelectedIndex(gc.getMelodyBlockTargetMode());
 		melodyPatternEffect.setSelectedIndex(gc.getMelodyPatternEffect());
+		melodyPatternFlexible.setSelected(gc.isMelodyPatternFlexible());
 		melodyRhythmAccents.setSelectedIndex(gc.getMelodyRhythmAccents());
 		melodyRhythmAccentsMode.setSelectedIndex(gc.getMelodyRhythmAccentsMode());
 		melodyRhythmAccentsPocket.setSelected(gc.isMelodyRhythmAccentsPocket());

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -5840,17 +5840,18 @@ public class VibeComposerGUI extends JFrame
 			// solve user chords
 			boolean customChords = userChordsEnabled.isSelected()
 					&& userChords.getChordletsRaw().size() > 0;
-			if ((customChords) || userDurationsEnabled.isSelected()) {
+			if (customChords || userDurationsEnabled.isSelected()) {
 				List<String> chords = userChords.getChordList();
 				List<Double> durations = new ArrayList<>();
 				String[] durationSplit = userChordsDurations.getText().split(",");
-				if ((userChordsEnabled.isSelected() && durationSplit.length < chords.size())
+				if ((customChords && durationSplit.length < chords.size())
 						|| !userDurationsEnabled.isSelected()) {
 					durationSplit = null;
 				}
 
 				try {
-					for (int i = 0; i < chords.size(); i++) {
+					for (int i = 0; i < (customChords ? chords.size()
+							: durationSplit.length); i++) {
 						durations.add(durationSplit != null
 								? (stretchMidi.getInt() * Double.valueOf(durationSplit[i]) / 100.0)
 								: MidiGenerator.Durations.WHOLE_NOTE);

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -7153,42 +7153,6 @@ public class VibeComposerGUI extends JFrame
 			tabPanePossibleChange = true;
 		}
 
-		if (ae.getActionCommand() == "CopyPart") {
-
-			JButton source = (JButton) ae.getSource();
-			InstPanel sourcePanel = (InstPanel) source.getParent();
-			InstPart part = null;
-
-			part = sourcePanel.toInstPart(lastRandomSeed);
-			InstPanel newPanel = addInstPanelToLayout(instrumentTabPane.getSelectedIndex(), part,
-					true);
-			newPanel.setPatternSeed(sourcePanel.getPatternSeed());
-
-			// todo checkbox set cc'd panel's midichannel?
-			if (true) {
-				newPanel.setMidiChannel(sourcePanel.getMidiChannel());
-			} else {
-				switch (instrumentTabPane.getSelectedIndex()) {
-				case 2:
-					newPanel.setMidiChannel(11 + (newPanel.getPanelOrder() - 1) % 5);
-					newPanel.setPanByOrder(5);
-					break;
-				case 3:
-					newPanel.setMidiChannel(2 + (newPanel.getPanelOrder() - 1) % 7);
-					newPanel.setPanByOrder(7);
-					break;
-				case 4:
-					newPanel.getComboPanel().reapplyHits();
-					break;
-				default:
-					break;
-				}
-			}
-			soloMuterPossibleChange = true;
-			tabPanePossibleChange = true;
-			//LG.i(("Set sequencer solo: " + sourcePanel.getMidiChannel()));
-		}
-
 		if (ae.getActionCommand() == "RandomizePart") {
 
 			JButton source = (JButton) ae.getSource();
@@ -7582,13 +7546,13 @@ public class VibeComposerGUI extends JFrame
 		return (sequencer != null) && (sequencer.isOpen()) && (sequencer.getSequence() != null);
 	}
 
-	private void recalculateGenerationCounts() {
+	public void recalculateGenerationCounts() {
 		randomChordsToGenerate.setText("" + Math.max(1, chordPanels.size()));
 		randomArpsToGenerate.setText("" + Math.max(1, arpPanels.size()));
 		randomDrumsToGenerate.setText("" + Math.max(1, drumPanels.size()));
 	}
 
-	private void recalculateTabPaneCounts() {
+	public void recalculateTabPaneCounts() {
 		instrumentTabPane.setTitleAt(0, "Melody (" + melodyPanels.size() + ")");
 		instrumentTabPane.setTitleAt(1, " Bass  (" + bassPanels.size() + ")");
 		instrumentTabPane.setTitleAt(2, "Chords (" + chordPanels.size() + ")");

--- a/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
+++ b/midimasterpiece/src/main/java/org/vibehistorian/vibecomposer/VibeComposerGUI.java
@@ -3760,7 +3760,7 @@ public class VibeComposerGUI extends JFrame
 		};
 		scoreScrollPane.setViewportView(scrollableScorePanel);
 
-		scoreScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
+		scoreScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
 		scoreScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
 		scoreScrollPane.getVerticalScrollBar().setUnitIncrement(16);
 		/*scoreScrollPane.getHorizontalScrollBar().addAdjustmentListener(new AdjustmentListener() {
@@ -5074,36 +5074,7 @@ public class VibeComposerGUI extends JFrame
 
 			@Override
 			public void mouseClicked(MouseEvent e) {
-				if (scorePanel != null) {
-					if (instrumentTabPane.getComponentCount() == 8) {
-						instrumentTabPane.remove(scoreScrollPane);
-						if (VibeComposerGUI.miniScorePopup.isSelected()) {
-							ShowPanelBig.beatWidthBase = 600;
-							ShowPanelBig.beatWidthBaseIndex = 0;
-							scorePanel.updatePanelHeight(300);
-							//scoreScrollPane.setMaximumSize(new Dimension(600, 300));
-							scorePanel.getShowArea().setNoteHeight(4);
-							scorePanel.setScore();
-							scorePanel.setAlignmentX(LEFT_ALIGNMENT);
-							scoreScrollPane.repaint();
-							/*SwingUtilities.invokeLater(() -> {
-								ShowPanelBig.zoomIn(ShowPanelBig.areaScrollPane, e.getPoint(), 0.0,
-										0.0);
-							});*/
-						}
-						scorePopup = new ShowScorePopup(scoreScrollPane);
-					} else {
-						if (scorePopup != null) {
-							scorePopup.close();
-							scorePopup = null;
-						}
-						if (instrumentTabPane.getComponentCount() < 8) {
-							instrumentTabPane.add(scoreScrollPane, 7);
-							instrumentTabPane.setTitleAt(7, " Score ");
-						}
-
-					}
-				}
+				toggleShowScorePopup();
 			}
 		});
 
@@ -7355,6 +7326,15 @@ public class VibeComposerGUI extends JFrame
 			slider.setUpperValue(slider.getValue());
 			resetPauseInfo();
 			LG.i(("Stopped Midi!"));
+			/*if (scorePopup != null) {
+				LG.i(ShowPanelBig.rulerScrollPane.getPreferredSize());
+				LG.i(ShowPanelBig.rulerScrollPane.getWidth());
+				LG.i(ShowPanelBig.areaScrollPane.getWidth());
+				LG.i(ShowPanelBig.horizontalPane.getWidth());
+				LG.i(scoreScrollPane.getWidth());
+				LG.i(scorePopup.getFrame().getWidth());
+			}*/
+
 		} else {
 			LG.i(("Sequencer is NULL!"));
 		}
@@ -9743,6 +9723,39 @@ public class VibeComposerGUI extends JFrame
 			device.getReceivers().forEach(e -> e.send(midiMessage, -1));
 		} else if (synth != null && synth.isOpen()) {
 			synth.getReceivers().forEach(e -> e.send(midiMessage, -1));
+		}
+	}
+
+	public void toggleShowScorePopup() {
+		if (scorePanel != null) {
+			if (instrumentTabPane.getComponentCount() == 8) {
+				instrumentTabPane.remove(scoreScrollPane);
+				if (VibeComposerGUI.miniScorePopup.isSelected()) {
+					ShowPanelBig.beatWidthBases = ShowPanelBig.beatWidthBasesSmall;
+					ShowPanelBig.beatWidthBase = ShowPanelBig.beatWidthBases
+							.get(ShowPanelBig.beatWidthBaseIndex);
+					scorePanel.updatePanelHeight(300);
+					//scoreScrollPane.setMaximumSize(new Dimension(600, 300));
+					scorePanel.getShowArea().setNoteHeight(4);
+					scorePanel.setScore();
+					scorePanel.setAlignmentX(LEFT_ALIGNMENT);
+					scoreScrollPane.repaint();
+					SwingUtilities.invokeLater(() -> {
+						ShowPanelBig.zoomIn(ShowPanelBig.areaScrollPane, new Point(0, 0), 0.0, 0.0);
+					});
+				}
+				scorePopup = new ShowScorePopup(scoreScrollPane);
+			} else {
+				if (scorePopup != null) {
+					scorePopup.close();
+					scorePopup = null;
+				}
+				if (instrumentTabPane.getComponentCount() < 8) {
+					instrumentTabPane.add(scoreScrollPane, 7);
+					instrumentTabPane.setTitleAt(7, " Score ");
+				}
+
+			}
 		}
 	}
 


### PR DESCRIPTION
* Support for any # of melody and bass parts (previously max. 3 and 1 respectively)

* Arp
  - contour (top notes) can be defined using new UI
  - "C" button causes the arp contour to shift up/down with the current chord, instead of repeating the same notes across the entire measure
  - New checkbox which enables melody dissonance avoidance (arps will try to avoid being +- 1 semitone away from a melody note that plays at the same time)

* New settings menu
  - sidebar with categories
  - ordered by importance

* Piano roll 
  - Ctrl+T to transpose selected notes
  - zooming (mouse wheel)
  - show notes outside margins if there are any outside of the standard measure (e.g. added via offsets/delays)

* Melody generation now allows creating new randomized blocks with a definable chance (instead of using presets only)

* Several new wacky scales to choose from (BbORIAN, EbOLIAN, AbRYGIAN, DbOCRIAN, GbF#)

* Score mini-popup now available

* Support for generating chord progressions with length based on what is entered into "custom durations" (also in sections)

* Chord transform tool, quick-shortcut chord transformations

* 2x faster initial startup, faster preset loading

* Many inconsistencies and bugs fixed (pattern visualization, dual-monitor flickering, beat looping behavior, CLR*/X* behavior, UI icons and checkbox placement, ...)



